### PR TITLE
use data.table prefix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,12 @@
 Package: PSPclean
 Type: Package
 Title: Sources and standardizes permanent sample plot data
-Version: 0.1.2
+Version: 0.1.2.9000
 Authors@R: c(
     person("Ian M S", "Eddy", email = "ian.eddy@nrcan.rncan.gc.ca",
-    role = c("aut", "cre"))
+           role = c("aut", "cre"))
+    person("Alex M", "Chubaty", email = "achubaty@for-cast.ca",
+           role = c("ctb"))
     )
 Depends:
     R (>= 3.6)

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -240,7 +240,7 @@ prepInputsAlbertaPSP <- function(dPath) {
   pspABtreeMeasure <- prepInputs(
     targetFile = file.path(dPath, "trees_measurement.csv"),
     url = "https://drive.google.com/file/d/1qGiHEpkeSjiHR73zhmSFEFq8BO8_9GTP/",
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE,
     destinationPath = dPath
   )
@@ -248,7 +248,7 @@ prepInputsAlbertaPSP <- function(dPath) {
   pspABtree <- prepInputs(
     targetFile = file.path(dPath, "trees.csv"),
     url = "https://drive.google.com/file/d/1qGiHEpkeSjiHR73zhmSFEFq8BO8_9GTP/",
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE,
     destinationPath = dPath
   )
@@ -264,7 +264,7 @@ prepInputsAlbertaPSP <- function(dPath) {
   pspABplot <- prepInputs(
     targetFile = file.path(dPath, "plot.csv"),
     url = "https://drive.google.com/file/d/1qGiHEpkeSjiHR73zhmSFEFq8BO8_9GTP/",
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE,
     destinationPath = dPath
   )

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -173,7 +173,7 @@ prepInputsBCPSP <- function(dPath) {
     url = "https://drive.google.com/file/d/1pBX5txiKFul3CyZ805seQ9-WNx624Mg4/",
     targetFile = "BCForestry_DamageAgentCodes.csv",
     destinationPath = dPath,
-    fun = "fread"
+    fun = "data.table::fread"
   )
   return(list(
     "plotHeaderDataRaw" = pspBCplot,

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -115,14 +115,14 @@ prepInputsNFIPSP <- function(dPath) {
     url = "https://drive.google.com/file/d/1S-4itShMXtwzGxjKPgsznpdTD2ydE9qn/",
     destinationPath = dPath,
     overwrite = TRUE,
-    fun = "fread"
+    fun = "data.table::fread"
   )
 
   pspNFIHeaderRaw <- prepInputs(
     targetFile = file.path(dPath, "all_gp_ltp_header.csv"),
     url = "https://drive.google.com/file/d/1i4y1Tfi-kpa5nHnpMbUDomFJOja5uD2g/",
     destinationPath = dPath,
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE
   )
 
@@ -130,7 +130,7 @@ prepInputsNFIPSP <- function(dPath) {
     targetFile = file.path(dPath, "all_gp_ltp_tree.csv"),
     url = "https://drive.google.com/file/d/1i4y1Tfi-kpa5nHnpMbUDomFJOja5uD2g/",
     destinationPath = dPath,
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE
   )
 
@@ -138,7 +138,7 @@ prepInputsNFIPSP <- function(dPath) {
     targetFile = file.path(dPath, "all_gp_ltp_tree_damage.csv"),
     url = "https://drive.google.com/file/d/1i4y1Tfi-kpa5nHnpMbUDomFJOja5uD2g/",
     destinationPath = dPath,
-    fun = "fread",
+    fun = "data.table::fread",
     overwrite = TRUE
   )
 


### PR DESCRIPTION
fairly minor change to specify `data.table::fread` in `prepInputs()` calls