### PR TITLE
Update Standardization of PSP Data Using LandR::sppEquivalencies_CA and Create PSP Cleaning Test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     data.table,
     dplyr,
     googledrive,
-    LandR (>= 1.1.5.9076),
+    LandR (>= 1.1.5.9086),
     magrittr, 
     reproducible (>= 2.0.3),
     sf,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     data.table,
     dplyr,
     googledrive,
-    LandR (>= 1.1.1.9001),
+    LandR (>= 1.1.5.9076),
     magrittr, 
     reproducible (>= 2.0.3),
     sf,

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -22,6 +22,9 @@ globalVariables(c(
 #' plots will be given a new ID column. Expressed as `min(PlotSize)/max(PlotSize)`
 #' remove all prior and future observations if `TRUE`.
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of plot and tree data.tables
 #'
 #' @export
@@ -29,7 +32,9 @@ globalVariables(c(
 #'
 dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
                                    codesToExclude = 3, excludeAllObs = TRUE,
-                                   areaDiffThresh = 0.95) {
+                                   areaDiffThresh = 0.95,
+                                   sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
   plot <- copy(plot)
   plotMeasure <- copy(plotMeasure)
   treeMeasure <- copy(treeMeasure)
@@ -76,7 +81,7 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   # estimate the difference between age measured at DBH and at stump
   # and apply it to DBH age so that all trees are approximately aged from stump (or total age where present)
   SADiff <- as.integer(mean(headerData_SA[!is.na(dbh_age) & !is.na(stump_age)]$stump_age -
-    headerData_SA[!is.na(dbh_age) & !is.na(stump_age)]$dbh_age))
+                              headerData_SA[!is.na(dbh_age) & !is.na(stump_age)]$dbh_age))
   headerData_SA <- headerData_SA[!is.na(dbh_age) & is.na(stump_age), stump_age := dbh_age + SADiff]
   headerData_SA[!is.na(total_age) & is.na(stump_age), stump_age := total_age]
 
@@ -88,7 +93,7 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
 
   # keep measurement_numbers > 1, but drop company plot numbers that don't match
   plotMeasure <- headerData_SA[plotMeasure[company_plot_number %in% headerData_SA$company_plot_number, ],
-    on = c("company_plot_number", "measurement_number")
+                               on = c("company_plot_number", "measurement_number")
   ]
 
   baseYear <- plotMeasure[measurement_number == 1]
@@ -119,8 +124,8 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   badConditions <- c(1, 2, 13, 14) # standing dead, dead down, cut down, missing
   # these must be removed no matter what
   treeMeasure <- treeMeasure[!condition_code1 %in% badConditions &
-    !condition_code2 %in% badConditions &
-    !condition_code3 %in% badConditions, ]
+                               !condition_code2 %in% badConditions &
+                               !condition_code3 %in% badConditions, ]
 
   # these are removed conditionally
   if (!is.null(codesToExclude)) {
@@ -171,10 +176,27 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   )]
   treeData <- treeMeasure[, .(MeasureID, OrigPlotID1, tree_number, species, dbh, height)]
 
-  setnames(treeData, c("species", "dbh", "height", "tree_number"), c("Species", "DBH", "Height", "TreeNumber"))
-  # species code changed since 2015 - now the second letter is uncapitalized.
-  treeData[, Species := toupper(Species)]
+  # ------------------------------------------------------------------------------------------
+  # Uppercase to standardize
+  treeData[, species := toupper(species)]
+  sppEquiv[, AB_forestry := toupper(AB_forestry)]
+
+  # Keep only valid, unique AB_forestry rows
+  sppEquiv <- sppEquiv[AB_forestry != "", .SD[1], by = AB_forestry]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("AB_forestry", sppEquivCol, "PSP")]
+
+  # Join to treeData
+  treeData <- sppEquiv[AB_forestry != "", .SD, .SDcols = c("AB_forestry", sppEquivCol, "PSP")][
+    treeData, on = c("AB_forestry" = "species"), allow.cartesian = TRUE
+  ]
+
+  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+
+  # Check
+  treeData[, .(AB_forestry, Species, newSpeciesName)]
+
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "ABPSP") # Need to add to pemisc
+  # -------------------------------------------------------------------------------------------------------
 
   setnames(
     headerData, c("measurement_year", "longitude", "latitude", "elevation"),
@@ -222,8 +244,8 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   treeData[MeasureID %in% trulyBad$MeasureID, OrigPlotID1 := paste0(OrigPlotID1, "f")]
 
   # final clean up
-  treeData[Height <= 0, Height := NA]
-  treeData <- treeData[!is.na(DBH) & DBH > 0]
+  treeData[height <= 0, height := NA]
+  treeData <- treeData[!is.na(dbh) & dbh > 0]
 
   headerData[, source := "AB"]
   treeData[, source := "AB"]

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -34,7 +34,7 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
                                    codesToExclude = 3, excludeAllObs = TRUE,
                                    areaDiffThresh = 0.95,
                                    sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
   plot <- copy(plot)
   plotMeasure <- copy(plotMeasure)
   treeMeasure <- copy(treeMeasure)
@@ -175,35 +175,24 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
     PlotSize, baseYear, baseSA
   )]
   treeData <- treeMeasure[, .(MeasureID, OrigPlotID1, tree_number, species, dbh, height)]
-  # ------------------------------------------------------------------------------------------
-  # Standadizing (Parvin added this part)
+
   setnames(treeData,
            old = c("tree_number", "species", "dbh", "height"),
            new = c( "TreeNumber", "Species", "DBH", "Height")
   )
-  # Uppercase to standardize
-  treeData[, Species := toupper(Species)]
-  sppEquiv[, AB_forestry := toupper(AB_forestry)]
-
-  # Keep unique rows only
+ # Standardize
+  sppEquiv <- sppEquiv[AB_forestry!= "", .SD, .SDcols = c("AB_forestry", sppEquivCol)]
   sppEquiv <- unique(sppEquiv)
-
-  # Select only necessary columns and join
-  sppEquiv <- sppEquiv[AB_forestry!= "", .SD[1], by = AB_forestry, .SDcols = c("AB_forestry", sppEquivCol, "PSP")]
 
   treeData <- sppEquiv[treeData, on = .(AB_forestry = Species)]
 
   # Rename joined columns
-  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+  setnames(treeData, old = c(AB_forestry, sppEquivCol), new = c("PSP", "Species"))
 
   # Check
-  treeData[, .(AB_forestry, Species, newSpeciesName)]
+  treeData[, .(PSP, Species)]
+  treeData[is.na(Species), Species := "unknown"]
 
-  treeData[, c("AB_forestry", "AB_forestry.1") := NULL]
-  # Standardize
-  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "ABPSP") # Need to add to pemisc
-
-  # -------------------------------------------------------------------------------------------------------
 
   setnames(
     headerData, c("measurement_year", "longitude", "latitude", "elevation"),
@@ -250,10 +239,11 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   headerData[, tempyear := NULL]
   treeData[MeasureID %in% trulyBad$MeasureID, OrigPlotID1 := paste0(OrigPlotID1, "f")]
 
-  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
-  setcolorder(treeData)
+  treeData <- treeData[, .(
+    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height
+  )]
 
-   # final clean up
+  # final clean up
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
 
@@ -261,19 +251,6 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   treeData[, source := "AB"]
 
   headerData <- headerData[OrigPlotID1 %in% treeData$OrigPlotID1]
-
-  # Handle missing species in one consolidated block
-  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
-  treeData[is.na(Species) | Species == "", Species := "unknown"]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown vs real in Species
-  treeData[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(
     plotHeaderData = headerData,

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -175,26 +175,35 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
     PlotSize, baseYear, baseSA
   )]
   treeData <- treeMeasure[, .(MeasureID, OrigPlotID1, tree_number, species, dbh, height)]
-
   # ------------------------------------------------------------------------------------------
+  # Standadizing (Parvin added this part)
+  setnames(treeData,
+           old = c("tree_number", "species", "dbh", "height"),
+           new = c( "TreeNumber", "Species", "DBH", "Height")
+  )
   # Uppercase to standardize
-  treeData[, species := toupper(species)]
+  treeData[, Species := toupper(Species)]
   sppEquiv[, AB_forestry := toupper(AB_forestry)]
 
-  # Keep only valid, unique AB_forestry rows
-  sppEquiv <- sppEquiv[AB_forestry != "", .SD[1], by = AB_forestry]
-  sppEquiv <- sppEquiv[, .SD, .SDcols = c("AB_forestry", sppEquivCol, "PSP")]
+  # Keep unique rows only
+  sppEquiv <- unique(sppEquiv)
 
-  # Join to treeData
-  treeData <- sppEquiv[AB_forestry != "", .SD, .SDcols = c("AB_forestry", sppEquivCol, "PSP")][
-    treeData, on = c("AB_forestry" = "species"), allow.cartesian = TRUE
-  ]
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[AB_forestry!= "", .SD[1], by = AB_forestry, .SDcols = c("AB_forestry", sppEquivCol, "PSP")]
 
+  treeData <- sppEquiv[treeData, on = .(AB_forestry = Species)]
+
+  # Rename joined columns
   setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
 
   # Check
   treeData[, .(AB_forestry, Species, newSpeciesName)]
 
+  treeData[, AB_forestry.1 := NULL]
+
+  treeData <- treeData[!(is.na(AB_forestry) | AB_forestry == "" | AB_forestry == "unknown")]
+
+  # Standardize
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "ABPSP") # Need to add to pemisc
   # -------------------------------------------------------------------------------------------------------
 
@@ -244,8 +253,8 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   treeData[MeasureID %in% trulyBad$MeasureID, OrigPlotID1 := paste0(OrigPlotID1, "f")]
 
   # final clean up
-  treeData[height <= 0, height := NA]
-  treeData <- treeData[!is.na(dbh) & dbh > 0]
+  treeData[Height <= 0, Height := NA]
+  treeData <- treeData[!is.na(DBH) & DBH > 0]
 
   headerData[, source := "AB"]
   treeData[, source := "AB"]

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -9,26 +9,31 @@ globalVariables(c(
   "tree_origin", "tree_plot_area", "trees_measurement_comment"
 ))
 
-#' standardize and treat the Alberta PSP data
+#' Standardize and Treat the Alberta PSP Data
 #'
-#' @param treeMeasure the tree measurement csv
-#' @param plotMeasure the plot_measurement csv
-#' @param tree the tree csv
-#' @param plot the plot csv
-#' @param codesToExclude damage agent codes used to filter tree data - see GOA PSP Manual.
-#' Measurements with these codes will be removed
-#' @param excludeAllObs if removing observations of individual trees due to damage codes,
-#' @param areaDiffThresh the threshold of plot size discrepancy to allow below which
-#' plots will be given a new ID column. Expressed as `min(PlotSize)/max(PlotSize)`
-#' remove all prior and future observations if `TRUE`.
+#' This function cleans and standardizes the Alberta PSP data, including tree measurements
+#' and plot information. Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param treeMeasure A `data.frame` or `data.table` containing tree measurement data.
+#' @param plotMeasure A `data.frame` or `data.table` containing plot measurement data.
+#' @param tree A `data.frame` or `data.table` containing tree information.
+#' @param plot A `data.frame` or `data.table` containing plot information.
+#' @param codesToExclude Character vector of damage agent codes used to filter tree data
+#'                       (see GOA PSP Manual). Measurements with these codes will be removed.
+#' @param excludeAllObs Logical. If `TRUE`, all prior and future observations of trees with
+#'                       codes in `codesToExclude` are removed.
+#' @param areaDiffThresh Numeric. Threshold for plot size discrepancy below which plots
+#'                       are assigned a new ID. Expressed as `min(PlotSize)/max(PlotSize)`.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table copy data.table set setcolorder setkey
+
 #'
 dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
                                    codesToExclude = 3, excludeAllObs = TRUE,

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -199,10 +199,10 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   # Check
   treeData[, .(AB_forestry, Species, newSpeciesName)]
 
-  treeData[, AB_forestry.1 := NULL]
+  # Fill missing AB_forestry with "unknown"
+  treeData[is.na(AB_forestry) | AB_forestry == "", AB_forestry := "unknown"]
 
-  treeData <- treeData[!(is.na(AB_forestry) | AB_forestry == "" | AB_forestry == "unknown")]
-
+  treeData[, c("AB_forestry", "AB_forestry.1") := NULL]
   # Standardize
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "ABPSP") # Need to add to pemisc
   # -------------------------------------------------------------------------------------------------------
@@ -251,6 +251,9 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   headerData[MeasureID %in% trulyBad$MeasureID, baseSA := baseSA + baseYear - tempyear, .(OrigPlotID1)]
   headerData[, tempyear := NULL]
   treeData[MeasureID %in% trulyBad$MeasureID, OrigPlotID1 := paste0(OrigPlotID1, "f")]
+
+  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
+  setcolorder(treeData)
 
   # final clean up
   treeData[Height <= 0, Height := NA]

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -187,11 +187,12 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   treeData <- sppEquiv[treeData, on = .(AB_forestry = Species)]
 
   # Rename joined columns
-  setnames(treeData, old = c(AB_forestry, sppEquivCol), new = c("PSP", "Species"))
+  setnames(treeData, old = c("AB_forestry", sppEquivCol), new = c("PSP", "Species"))
 
   # Check
   treeData[, .(PSP, Species)]
-  treeData[is.na(Species), Species := "unknown"]
+  treeData[is.na(Species)| Species == "", Species := "unknown"]
+  treeData[is.na(PSP) | PSP == "", PSP := "unknown"]
 
 
   setnames(

--- a/R/AlbertaPSP.R
+++ b/R/AlbertaPSP.R
@@ -199,12 +199,10 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   # Check
   treeData[, .(AB_forestry, Species, newSpeciesName)]
 
-  # Fill missing AB_forestry with "unknown"
-  treeData[is.na(AB_forestry) | AB_forestry == "", AB_forestry := "unknown"]
-
   treeData[, c("AB_forestry", "AB_forestry.1") := NULL]
   # Standardize
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "ABPSP") # Need to add to pemisc
+
   # -------------------------------------------------------------------------------------------------------
 
   setnames(
@@ -255,7 +253,7 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
   setcolorder(treeData)
 
-  # final clean up
+   # final clean up
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
 
@@ -263,6 +261,19 @@ dataPurification_ABPSP <- function(treeMeasure, plotMeasure, tree, plot,
   treeData[, source := "AB"]
 
   headerData <- headerData[OrigPlotID1 %in% treeData$OrigPlotID1]
+
+  # Handle missing species in one consolidated block
+  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
+  treeData[is.na(Species) | Species == "", Species := "unknown"]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown vs real in Species
+  treeData[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(
     plotHeaderData = headerData,

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -149,9 +149,10 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   # Optional check
   treeData[, .(BC_Forestry, Species, newSpeciesName)]
 
-  treeData[, BC_Forestry.1 := NULL]
+  # Fill missing BC_Forestry with "unknown"
+  treeData[is.na(BC_Forestry) | BC_Forestry == "", BC_Forestry := "unknown"]
 
-  treeData <- treeData[!(is.na(BC_Forestry) | BC_Forestry == "" | BC_Forestry == "unknown")]
+  treeData[, c("BC_Forestry", "BC_Forestry.1") := NULL]
 
   # Standardize
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP")
@@ -170,6 +171,9 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   }
 
   treeData[, TreeNumber := as.numeric(as.factor(TreeNumber))]
+
+  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
+  setcolorder(treeData)
 
   headerData[, source := "BC"]
   treeData[, source := "BC"]

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -16,24 +16,29 @@ globalVariables(c(
 #' @param excludeAllObs if removing observations of individual trees due to damage codes,
 #' remove all prior and future observations if `TRUE`.
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of plot and tree data.tables
 #'
 #' @export
 #' @importFrom data.table setnames setkey copy
 #'
 dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCodes,
-                                   codesToExclude = "IBM", excludeAllObs = TRUE) {
+                                   codesToExclude = "IBM", excludeAllObs = TRUE,
+                                   sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
   treeDataRaw <- copy(treeDataRaw)
   plotHeaderDataRaw <- copy(plotHeaderDataRaw)
 
   headerData <- plotHeaderDataRaw[tot_stand_age != -99, ][
     , ":="(utmtimes = length(unique(utm_zone)),
-      eastingtimes = length(unique(utm_easting)),
-      northingtimes = length(unique(utm_northing)),
-      SAtimes = length(unique(tot_stand_age)),
-      plotsizetimes = length(unique(area_pm)),
-      standorigtimes = length(unique(stnd_org)),
-      treatmenttimes = length(unique(treatment))),
+           eastingtimes = length(unique(utm_easting)),
+           northingtimes = length(unique(utm_northing)),
+           SAtimes = length(unique(tot_stand_age)),
+           plotsizetimes = length(unique(area_pm)),
+           standorigtimes = length(unique(stnd_org)),
+           treatmenttimes = length(unique(treatment))),
     by = SAMP_ID
   ]
 
@@ -60,8 +65,8 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   headerData <- headerData[!is.na(area_pm), ][, ":="(tot_stand_age = NULL, meas_yr = NULL)]
 
   setnames(headerData,
-    old = c("SAMP_ID", "utm_zone", "utm_easting", "utm_northing", "area_pm"),
-    new = c("OrigPlotID1", "Zone", "Easting", "Northing", "PlotSize")
+           old = c("SAMP_ID", "utm_zone", "utm_easting", "utm_northing", "area_pm"),
+           new = c("OrigPlotID1", "Zone", "Easting", "Northing", "PlotSize")
   )
   headerData <- unique(headerData, by = c("OrigPlotID1"))
 
@@ -105,12 +110,12 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
 
   # unique(treeData$ld)
   setnames(treeData,
-    old = c("meas_yr", "tree_no", "species", "dbh", "height"),
-    new = c("MeasureYear", "TreeNumber", "Species", "DBH", "Height")
+           old = c("meas_yr", "tree_no", "species", "dbh", "height"),
+           new = c("MeasureYear", "TreeNumber", "Species", "DBH", "Height")
   )
 
   measureidtable <- unique(treeData[, .(OrigPlotID1, OrigPlotID2, MeasureYear)],
-    by = c("OrigPlotID1", "OrigPlotID2", "MeasureYear")
+                           by = c("OrigPlotID1", "OrigPlotID2", "MeasureYear")
   )
   measureidtable[, MeasureID := paste("BCPSP_", row.names(measureidtable), sep = "")]
   measureidtable <- measureidtable[, .(MeasureID, OrigPlotID1, OrigPlotID2, MeasureYear)]
@@ -119,14 +124,36 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
 
   set(headerData, NULL, "OrigPlotID2", NULL)
   headerData <- headerData[, .(MeasureID, OrigPlotID1, MeasureYear,
-    Longitude = NA,
-    Latitude = NA, Zone, Easting, Northing, Elevation,
-    PlotSize, baseYear, baseSA
+                               Longitude = NA,
+                               Latitude = NA, Zone, Easting, Northing, Elevation,
+                               PlotSize, baseYear, baseSA
   )]
   measureidtable <- setkey(measureidtable, OrigPlotID1, OrigPlotID2, MeasureYear)
   treeData <- measureidtable[setkey(treeData, OrigPlotID1, OrigPlotID2, MeasureYear), nomatch = 0]
 
+  # -------------------------------------------------------------------------------------------------
+  # Uppercase to standardize
+  treeData[, Species := toupper(Species)]
+  sppEquiv[, BC_Forestry := toupper(BC_Forestry)]
+
+  # # Keep only valid, unique BC_Forestry rows
+  sppEquiv <- sppEquiv[BC_Forestry != "", .SD[1], by = BC_Forestry]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")]
+
+  # Join to treeData
+  treeData <- sppEquiv[BC_Forestry != "", .SD, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")][
+    treeData, on = c("BC_Forestry" = "Species"), allow.cartesian = TRUE
+  ]
+  #treeData <- sppEquiv[treeData, on = c("AB_forestry" = "Species")]
+
+  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+
+
+  # Check
+  treeData[, .(BC_Forestry, Species, newSpeciesName)]
+
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP") # Need to add to pemisc
+  # -------------------------------------------------------------------------------------------------------
 
   treeData$OrigPlotID1 <- paste0("BCPSP", treeData$OrigPlotID1)
   headerData$OrigPlotID1 <- paste0("BCPSP", headerData$OrigPlotID1)

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -27,7 +27,7 @@ globalVariables(c(
 dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCodes,
                                    codesToExclude = "IBM", excludeAllObs = TRUE,
                                    sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
   treeDataRaw <- copy(treeDataRaw)
   plotHeaderDataRaw <- copy(plotHeaderDataRaw)
 
@@ -131,29 +131,21 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   measureidtable <- setkey(measureidtable, OrigPlotID1, OrigPlotID2, MeasureYear)
   treeData <- measureidtable[setkey(treeData, OrigPlotID1, OrigPlotID2, MeasureYear), nomatch = 0]
 
-  # -------------------------------------------------------------------------------------------------
-  # Uppercase to standardize (Parvin added this part)
-  treeData[, Species := toupper(Species)]
-  sppEquiv[, BC_Forestry := toupper(BC_Forestry)]
-
+  # Standardize
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[BC_Forestry != "", .SD, .SDcols = c("BC_Forestry", sppEquivCol)]
   # Keep unique rows only
   sppEquiv <- unique(sppEquiv)
 
-  # Select only necessary columns and join
-  sppEquiv <- sppEquiv[BC_Forestry != "", .SD[1], by = BC_Forestry, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")]
   treeData <- sppEquiv[treeData, on = .(BC_Forestry = Species)]
 
   # Rename joined columns
-  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+  setnames(treeData, old = c(BC_Forestry, sppEquivCol), new = c("PSP", "Species"))
 
-  # Optional check
-  treeData[, .(BC_Forestry, Species, newSpeciesName)]
+  # Check
+  treeData[, .(PSP, Species)]
+  treeData[is.na(Species), Species := "unknown"]
 
-  treeData[, c("BC_Forestry", "BC_Forestry.1") := NULL]
-
-  # Standardize
-  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP")
-  # -------------------------------------------------------------------------------------------------------
 
   treeData$OrigPlotID1 <- paste0("BCPSP", treeData$OrigPlotID1)
   headerData$OrigPlotID1 <- paste0("BCPSP", headerData$OrigPlotID1)
@@ -169,26 +161,12 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   treeData[, TreeNumber := as.numeric(as.factor(TreeNumber))]
 
   treeData <- treeData[, .(
-    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH
+    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height
   )]
+
 
   headerData[, source := "BC"]
   treeData[, source := "BC"]
-
-
-  # Handle missing species in one consolidated block
-  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
-  treeData[is.na(Species) | Species == "", Species := "unknown"]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-   # Count of unknown vs real in Species
-  treeData[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
-
 
   return(list(
     "plotHeaderData" = headerData,

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -133,19 +133,20 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
 
   # Standardize
   # Select only necessary columns and join
-  sppEquiv <- sppEquiv[BC_Forestry != "", .SD, .SDcols = c("BC_Forestry", sppEquivCol)]
+  sppEquiv <- sppEquiv[BC_forestry != "", .SD, .SDcols = c("BC_forestry", sppEquivCol)]
   # Keep unique rows only
   sppEquiv <- unique(sppEquiv)
+  sppEquiv[, BC_forestry := toupper(BC_forestry)]
 
-  treeData <- sppEquiv[treeData, on = .(BC_Forestry = Species)]
+  treeData <- sppEquiv[treeData, on = .(BC_forestry = Species)]
 
   # Rename joined columns
-  setnames(treeData, old = c(BC_Forestry, sppEquivCol), new = c("PSP", "Species"))
+  setnames(treeData, old = c("BC_forestry", sppEquivCol), new = c("PSP", "Species"))
 
   # Check
   treeData[, .(PSP, Species)]
-  treeData[is.na(Species), Species := "unknown"]
-
+  treeData[is.na(Species)| Species == "", Species := "unknown"]
+  treeData[is.na(PSP) | PSP == "", PSP := "unknown"]
 
   treeData$OrigPlotID1 <- paste0("BCPSP", treeData$OrigPlotID1)
   headerData$OrigPlotID1 <- paste0("BCPSP", headerData$OrigPlotID1)

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -7,23 +7,27 @@ globalVariables(c(
   "tree_cls", "tree_no", "utm_easting", "utm_northing", "utm_zone", "zone"
 ))
 
-#' standardize and treat the BC PSP data
+#' #' Standardize and Treat the BC PSP Data
 #'
-#' @param treeDataRaw the tree measurement csv
-#' @param plotHeaderDataRaw the plot header csv
-#' @param damageAgentCodes vector of damage agent codes
-#' @param codesToExclude damage agents to exclude from measurements
-#' @param excludeAllObs if removing observations of individual trees due to damage codes,
-#' remove all prior and future observations if `TRUE`.
+#' This function cleans and standardizes the British Columbia PSP data, including tree measurements
+#' and plot header information. Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param treeDataRaw A `data.frame` or `data.table` containing the raw tree measurement data.
+#' @param plotHeaderDataRaw A `data.frame` or `data.table` containing the raw plot header data.
+#' @param damageAgentCodes A character vector of damage agent codes present in the data.
+#' @param codesToExclude A character vector of damage agent codes to exclude from measurements.
+#' @param excludeAllObs Logical. If `TRUE`, all prior and future observations of a tree with a damage code
+#'                       in `codesToExclude` are removed. Default is `TRUE`.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table setnames setkey copy
-#'
+
 dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCodes,
                                    codesToExclude = "IBM", excludeAllObs = TRUE,
                                    sppEquiv = LandR::sppEquivalencies_CA,

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -132,27 +132,30 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   treeData <- measureidtable[setkey(treeData, OrigPlotID1, OrigPlotID2, MeasureYear), nomatch = 0]
 
   # -------------------------------------------------------------------------------------------------
-  # Uppercase to standardize
+  # Uppercase to standardize (Parvin added this part)
   treeData[, Species := toupper(Species)]
   sppEquiv[, BC_Forestry := toupper(BC_Forestry)]
 
-  # # Keep only valid, unique BC_Forestry rows
-  sppEquiv <- sppEquiv[BC_Forestry != "", .SD[1], by = BC_Forestry]
-  sppEquiv <- sppEquiv[, .SD, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")]
+  # Keep unique rows only
+  sppEquiv <- unique(sppEquiv)
 
-  # Join to treeData
-  treeData <- sppEquiv[BC_Forestry != "", .SD, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")][
-    treeData, on = c("BC_Forestry" = "Species"), allow.cartesian = TRUE
-  ]
-  #treeData <- sppEquiv[treeData, on = c("AB_forestry" = "Species")]
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[BC_Forestry != "", .SD[1], by = BC_Forestry, .SDcols = c("BC_Forestry", sppEquivCol, "PSP")]
+  treeData <- sppEquiv[treeData, on = .(BC_Forestry = Species)]
 
+  # Rename joined columns
   setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
 
-
-  # Check
+  # Optional check
   treeData[, .(BC_Forestry, Species, newSpeciesName)]
 
-  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP") # Need to add to pemisc
+  treeData[, BC_Forestry.1 := NULL]
+
+  treeData <- treeData[!(is.na(BC_Forestry) | BC_Forestry == "" | BC_Forestry == "unknown")]
+
+  # Standardize
+  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP")
+
   # -------------------------------------------------------------------------------------------------------
 
   treeData$OrigPlotID1 <- paste0("BCPSP", treeData$OrigPlotID1)

--- a/R/BCPSP.R
+++ b/R/BCPSP.R
@@ -149,14 +149,10 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
   # Optional check
   treeData[, .(BC_Forestry, Species, newSpeciesName)]
 
-  # Fill missing BC_Forestry with "unknown"
-  treeData[is.na(BC_Forestry) | BC_Forestry == "", BC_Forestry := "unknown"]
-
   treeData[, c("BC_Forestry", "BC_Forestry.1") := NULL]
 
   # Standardize
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "BCPSP")
-
   # -------------------------------------------------------------------------------------------------------
 
   treeData$OrigPlotID1 <- paste0("BCPSP", treeData$OrigPlotID1)
@@ -172,11 +168,27 @@ dataPurification_BCPSP <- function(treeDataRaw, plotHeaderDataRaw, damageAgentCo
 
   treeData[, TreeNumber := as.numeric(as.factor(TreeNumber))]
 
-  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
-  setcolorder(treeData)
+  treeData <- treeData[, .(
+    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH
+  )]
 
   headerData[, source := "BC"]
   treeData[, source := "BC"]
+
+
+  # Handle missing species in one consolidated block
+  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
+  treeData[is.na(Species) | Species == "", Species := "unknown"]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+   # Count of unknown vs real in Species
+  treeData[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
+
 
   return(list(
     "plotHeaderData" = headerData,

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -64,7 +64,6 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   }
   # meas_num is needed to match damage, but not afterward
   treeData[, meas_num := NULL]
-
   setnames(
     treeData, c("nfi_plot", "year", "tree_num", "lgtree_genus", "lgtree_species", "dbh", "height"),
     c("OrigPlotID1", "MeasureYear", "TreeNumber", "Genus", "Species", "DBH", "Height")
@@ -72,8 +71,8 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
 
   # names(lgpHeader) <- c("OrigPlotID1", "baseYear", "PlotSize", "baseSA", "Northing", "Easting", "Zone", "Elevation")
   setnames(lgpHeader,
-    old = c("nfi_plot", "year", "meas_plot_size", "site_age", "utm_n", "utm_e", "utm_zone", "elevation"),
-    new = c("OrigPlotID1", "baseYear", "PlotSize", "baseSA", "Northing", "Easting", "Zone", "Elevation")
+           old = c("nfi_plot", "year", "meas_plot_size", "site_age", "utm_n", "utm_e", "utm_zone", "elevation"),
+           new = c("OrigPlotID1", "baseYear", "PlotSize", "baseSA", "Northing", "Easting", "Zone", "Elevation")
   )
 
   lgpHeader <- unique(lgpHeader, by = "OrigPlotID1")
@@ -91,20 +90,41 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
     TreeNumber, Genus, Species, DBH, Height
   )]
   lgpHeader <- lgpHeader[, .(MeasureID, OrigPlotID1, MeasureYear,
-    Longitude = NA, Latitude = NA, Zone,
-    Easting, Northing, Elevation, PlotSize, baseYear, baseSA
+                             Longitude = NA, Latitude = NA, Zone,
+                             Easting, Northing, Elevation, PlotSize, baseYear, baseSA
   )]
 
-  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "NFIPSP") # Need to add to pemisc
+  # ------------------------------------------------------------------------------------------
+  # Standardize species names using PSPclean (Parvin added this part)
 
-  treeData[, Species := paste0(Genus, "_", Species)]
-  treeData[, Genus := NULL] # This column is not in any of the other PSP datasets
+  treeData[, SpeciesCode := toupper(paste0(Genus, "_", Species))]
+
+  treeData[, Species := NULL]
+
+  # Only keep the PSP column as the standardized species name
+  sppEquiv <- sppEquiv[, .SD[], .SDcols = c(sppEquivCol,"NFI","PSP")]
+
+  # Keep unique rows only
+  sppEquiv <- unique(sppEquiv)
+
+  # Join correctly
+  treeData <- sppEquiv[treeData, on = .(NFI = SpeciesCode)]
+
+  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+
+  # Fill missing NFI with "unknown"
+  treeData[is.na(NFI) | NFI == "", NFI := "unknown"]
+
+  # ------------------------------------------------------------------------------------------
+  treeData[, c("NFI", "Genus") := NULL] # This "Genus" column is not in any of the other PSP datasets
 
   treeData$OrigPlotID1 <- paste0("NFIPSP", treeData$OrigPlotID1)
   lgpHeader$OrigPlotID1 <- paste0("NFIPSP", lgpHeader$OrigPlotID1)
 
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
+
+  treeData <- treeData[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)]
 
   lgpHeader[, source := "NFI"]
   treeData[, source := "NFI"]

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -24,7 +24,7 @@ utils::globalVariables(c(
 #' @importFrom data.table copy setkey set
 dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllObs = TRUE
                                     , sppEquiv = LandR::sppEquivalencies_CA,
-                                    sppEquivCol = "LandR") {
+                                      sppEquivCol = "Latin_full") {
 
   lgptreeRaw <- copy(NFIdata[["pspTreeMeasure"]])
   lgpHeaderRaw <- copy(NFIdata[["pspHeader"]])
@@ -94,15 +94,12 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
                              Easting, Northing, Elevation, PlotSize, baseYear, baseSA
   )]
 
-  # ------------------------------------------------------------------------------------------
-  # Standardize species names using PSPclean (Parvin added this part)
-
-  treeData[, SpeciesCode := toupper(paste0(Genus, "_", Species))]
+  treeData[, SpeciesCode := paste0(Genus, "_", Species)]
 
   treeData[, Species := NULL]
 
   # Only keep the PSP column as the standardized species name
-  sppEquiv <- sppEquiv[, .SD[], .SDcols = c(sppEquivCol,"NFI","PSP")]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c(sppEquivCol,"NFI")]
 
   # Keep unique rows only
   sppEquiv <- unique(sppEquiv)
@@ -110,9 +107,13 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   # Join correctly
   treeData <- sppEquiv[treeData, on = .(NFI = SpeciesCode)]
 
-  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
-  # ------------------------------------------------------------------------------------------
-  treeData[, c("NFI", "Genus") := NULL] # This "Genus" column is not in any of the other PSP datasets
+  setnames(treeData, old = c(sppEquivCol, "NFI"), new = c("Species", "PSP"))
+
+  # Check
+  treeData[, .(PSP, Species)]
+  treeData[is.na(Species), Species := "unknown"]
+
+  treeData[, "Genus" := NULL] # This "Genus" column is not in any of the other PSP datasets
 
   treeData$OrigPlotID1 <- paste0("NFIPSP", treeData$OrigPlotID1)
   lgpHeader$OrigPlotID1 <- paste0("NFIPSP", lgpHeader$OrigPlotID1)
@@ -120,23 +121,10 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
 
-  treeData <- treeData[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)]
+  treeData <- treeData[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height)]
 
   lgpHeader[, source := "NFI"]
   treeData[, source := "NFI"]
-
-  # Handle missing species in one consolidated block
-  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
-  treeData[is.na(Species) | Species == "", Species := "unknown"]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown vs real in Species
-  treeData[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(
     "plotHeaderData" = lgpHeader,

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -97,6 +97,7 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   treeData[, SpeciesCode := paste0(Genus, "_", Species)]
 
   treeData[, Species := NULL]
+  sppEquiv <- sppEquiv[!(sppEquiv$NFI == "" & sppEquiv$Latin_full == ""), ]
 
   # Only keep the PSP column as the standardized species name
   sppEquiv <- sppEquiv[, .SD, .SDcols = c(sppEquivCol,"NFI")]
@@ -111,7 +112,9 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
 
   # Check
   treeData[, .(PSP, Species)]
-  treeData[is.na(Species), Species := "unknown"]
+
+  treeData[is.na(Species)| Species == "", Species := "unknown"]
+  treeData[is.na(PSP) | PSP == "", PSP := "unknown"]
 
   treeData[, "Genus" := NULL] # This "Genus" column is not in any of the other PSP datasets
 

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -32,11 +32,11 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   treeDamage <- NFIdata[["pspTreeDamage"]]
 
   lgptreeRaw <- lgptreeRaw[orig_plot_area == "Y", ]
+
   # start from tree data to obtain plot infor
-  lgptreeRaw[, year := as.Date(meas_date, format = "%Y-%B-%d")]
-  lgpHeaderRaw[, year := as.Date(meas_date, format = "%Y-%B-%d")]
-  lgptreeRaw[, year := as.numeric(format(year, "%Y"))]
-  lgpHeaderRaw[, year := as.numeric(format(year, "%Y"))]
+  lgptreeRaw[, year := as.numeric(format(as.Date(meas_date, "%Y-%B-%d"), "%Y"))]
+  lgpHeaderRaw[, year := as.numeric(format(as.Date(meas_date, "%Y-%B-%d"), "%Y"))]
+
 
   lgpHeader <- lgpHeaderRaw[nfi_plot %in% unique(lgptreeRaw$nfi_plot), ][, .(nfi_plot, year, meas_plot_size, site_age)]
   approxLocation <- approxLocation[, .(nfi_plot, utm_n, utm_e, utm_zone, elevation)]
@@ -111,10 +111,6 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
   treeData <- sppEquiv[treeData, on = .(NFI = SpeciesCode)]
 
   setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
-
-  # Fill missing NFI with "unknown"
-  treeData[is.na(NFI) | NFI == "", NFI := "unknown"]
-
   # ------------------------------------------------------------------------------------------
   treeData[, c("NFI", "Genus") := NULL] # This "Genus" column is not in any of the other PSP datasets
 
@@ -128,6 +124,19 @@ dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllOb
 
   lgpHeader[, source := "NFI"]
   treeData[, source := "NFI"]
+
+  # Handle missing species in one consolidated block
+  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
+  treeData[is.na(Species) | Species == "", Species := "unknown"]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown vs real in Species
+  treeData[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(
     "plotHeaderData" = lgpHeader,

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -15,11 +15,16 @@ utils::globalVariables(c(
 #' @param excludeAllObs if removing observations of individual trees due to damage codes,
 #' remove all prior and future observations if `TRUE`.
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of plot and tree data.tables
 #'
 #' @export
 #' @importFrom data.table copy setkey set
-dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllObs = TRUE) {
+dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllObs = TRUE
+                                    , sppEquiv = LandR::sppEquivalencies_CA,
+                                    sppEquivCol = "LandR") {
 
   lgptreeRaw <- copy(NFIdata[["pspTreeMeasure"]])
   lgpHeaderRaw <- copy(NFIdata[["pspHeader"]])

--- a/R/NFIPSP.R
+++ b/R/NFIPSP.R
@@ -8,20 +8,25 @@ utils::globalVariables(c(
   "year", "Zone", "meas_date"
 ))
 
-#' standardize and treat the NFI PSP data
+#' #' Standardize and Treat the NFI PSP Data
 #'
-#' @param NFIdata list of NFI tree, plot, and location data
-#' @param codesToExclude damage agents to exclude from measurements
-#' @param excludeAllObs if removing observations of individual trees due to damage codes,
-#' remove all prior and future observations if `TRUE`.
+#' This function cleans and standardizes NFI PSP data, including tree, plot, and location data.
+#' Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param NFIdata A list containing NFI tree, plot, and location data.tables.
+#' @param codesToExclude Vector of damage agent codes. Measurements with these codes will be removed.
+#' @param excludeAllObs Logical. If `TRUE`, removing observations of individual trees due to damage codes
+#'                       will also remove all prior and future observations of that tree.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table copy setkey set
+
 dataPurification_NFIPSP <- function(NFIdata, codesToExclude = "IB", excludeAllObs = TRUE
                                     , sppEquiv = LandR::sppEquivalencies_CA,
                                       sppEquivCol = "Latin_full") {

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -147,13 +147,13 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
 
   PSP_TREE_YIMO[, .(NB_forestry, Species, newSpeciesName)]
 
-  PSP_TREE_YIMO[, NB_forestry.1 := NULL]
-  PSP_TREE_YIMO[, i.Species := NULL]
+  PSP_TREE_YIMO[, c("i.Species","NB_forestry.1") := NULL]
 
-  PSP_TREE_YIMO <- PSP_TREE_YIMO[!(is.na(NB_forestry) | NB_forestry == "" | NB_forestry == "unknown")]
+  # Fill missing NB_forestry with "unknown"
+  PSP_TREE_YIMO [is.na(NB_forestry) | NB_forestry== "", NB_forestry := "unknown"]
 
   PSP_TREE_YIMO <- PSP_TREE_YIMO[, .(
-    NB_forestry, MeasureID, OrigPlotID1, MeasureYear,TreeNumber,Species,DBH,newSpeciesName
+     MeasureID, OrigPlotID1, MeasureYear, Species, newSpeciesName, TreeNumber,DBH
   )]
 
 

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -6,18 +6,22 @@ globalVariables(c(
   "OrigPlotID1","MeasureYear","PlotSize","baseSA","LATITUDE","LONGITUDE"
 ))
 
-#' standardize and treat the New Brunswick PSP data
+#' Standardize and Treat the New Brunswick PSP Data
 #'
-#' @param NB_PSP_Data list of data tables resulting from `prepInputsNBPSP`
-#' @param sppEquiv species equivalencies table with column `Latin-full`
+#' This function cleans and standardizes New Brunswick PSP data, including tree and plot data.
+#' Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param NB_PSP_Data A list of `data.table`s resulting from `prepInputsNBPSP`, containing raw PSP data.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of standardized plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table set setcolorder
+
 dataPurification_NBPSP <- function(NB_PSP_Data,
                                    sppEquiv = LandR::sppEquivalencies_CA,
                                    sppEquivCol = "Latin_full") {

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -20,7 +20,7 @@ globalVariables(c(
 #' @importFrom data.table set setcolorder
 dataPurification_NBPSP <- function(NB_PSP_Data,
                                    sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
 
   PSP_PLOTS <- NB_PSP_Data[["PSP_PLOTS"]]
   PSP_PLOTS_YR <- NB_PSP_Data[["PSP_PLOTS_YR"]]
@@ -84,15 +84,15 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
   sppNB <- NB_PSP_Data[["LookUp_Species"]][, .(species, LatinName, CommonName)]
   PSP_TREE_YIMO[is.na(species), species := 999] #coded as unknown in table
 
-  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "NB_forestry", "Latin_full", "PSP")])
+  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "NB_forestry")])
   PSP_TREE_YIMO <- sppNB[PSP_TREE_YIMO, on = c("species")]
   PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = c("Latin_full" = "LatinName")]
-  #note that most species lack biomass equations
-  PSP_TREE_YIMO[is.na(PSP)|PSP == "", PSP := CommonName]
+  # #note that most species lack biomass equations
+  # PSP_TREE_YIMO[is.na(PSP)|PSP == "", PSP := CommonName]
   PSP_TREE_YIMO[, c("species", "CommonName") := NULL]
 
   #this ensures elm trees have biomass equations (they are very likely white elms)...
-  PSP_TREE_YIMO[Latin_full == "Ulmus spp.", PSP := "white elm"]
+  # PSP_TREE_YIMO[Latin_full == "Ulmus spp.", PSP := "white elm"]
 
   PSP_LOC_LAT_LONG <- PSP_LOC_LAT_LONG[, .(PLOT, lat, long_)]
   PSP_PLOTS[, Plot := as.integer(Plot)]
@@ -115,23 +115,21 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
            new = c("OrigPlotID1", "Latitude", "Longitude", "MeasureID", "MeasureYear"))
 
   setnames(PSP_TREE_YIMO,
-           old = c("LandR", "PSP", "RemeasID", "treenum", "Plot", "MeasYr"),
-           new = c("Species", "newSpeciesName", "MeasureID", "TreeNumber", "OrigPlotID1", "MeasureYear"))
+           old = c("Latin_full", "NB_forestry", "RemeasID", "treenum", "Plot", "MeasYr"),
+           new = c("Species", "PSP", "MeasureID", "TreeNumber", "OrigPlotID1", "MeasureYear"))
 
+  # Check
+  PSP_TREE_YIMO[, .(PSP, Species)]
+  PSP_TREE_YIMO[is.na(Species), Species := "unknown"]
 
-  setcolorder(PSP_TREE_YIMO, c("MeasureID", "OrigPlotID1", "MeasureYear",
-                               "TreeNumber", "Species", "DBH", "newSpeciesName"))
 
   plotCols <- c("MeasureID", "OrigPlotID1", "MeasureYear", "Longitude",
                 "Latitude", "PlotSize", "baseYear", "baseSA")
-
   PSP_PLOTS <- PSP_PLOTS[, .SD, .SDcol = plotCols]
 
   PSP_TREE_YIMO <- PSP_TREE_YIMO[, .(
-     MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH
+     MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH
   )]
-
-
   #assign NB
   PSP_TREE_YIMO[, OrigPlotID1 := paste0("NBPSP_", OrigPlotID1)]
   PSP_PLOTS[, OrigPlotID1 := paste0("NBPSP_", OrigPlotID1)]
@@ -140,20 +138,6 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
 
   PSP_PLOTS[, source := "NB"]
   PSP_TREE_YIMO[, source := "NB"]
-
-
-  # Handle missing species in one consolidated block
-  PSP_TREE_YIMO[is.na(Species) | Species == "", Species := newSpeciesName]
-  PSP_TREE_YIMO[is.na(Species) | Species == "", Species := "unknown"]
-  PSP_TREE_YIMO[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  PSP_TREE_YIMO[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown species
-  PSP_TREE_YIMO[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(
     "plotHeaderData" = PSP_PLOTS,

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -27,24 +27,17 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
   PSP_TREE_YIMO <- NB_PSP_Data[["PSP_TREE_YIMO"]]
   PSP_LOC_LAT_LONG <- NB_PSP_Data[["PSP_LOC_LAT_LONG"]]
 
-  #start by taking the YIMO
-  #these are the young immature mature and overmature plots
-  PSP_PLOTS <- PSP_PLOTS[PlotType == "M",]
-  PSP_PLOTS <- PSP_PLOTS[SilvID == 0]
+  # Filter plots
+  PSP_PLOTS <- PSP_PLOTS[PlotType == "M" & SilvID == 0]
 
-  #get rid of bad measurements - trees were numbered differently in 4th measure of 5
-  PSP_PLOTS_YR <- PSP_PLOTS_YR[!RemeasID %in% "10405_4",]
+  # Remove bad measurements
+  PSP_PLOTS_YR <- PSP_PLOTS_YR[!RemeasID %in% "10405_4"]
   PSP_TREE_YIMO <- PSP_TREE_YIMO[!RemeasID %in% "10405_4"]
-
-  #no dead trees
   PSP_TREE_YIMO <- PSP_TREE_YIMO[!cause %in% 1:9]
-  # has age
 
-  #Miscellaenous fixes - filter before calculating base stand age
-  #these tree numbers are inconsistent in the 5th meaurement -
+  # Misc fixes
   PSP_TREE_YIMO[RemeasID == "5040_5" & treenum  > 100, treenum := treenum + 200]
   PSP_TREE_YIMO[RemeasID == "5040_5" & treenum  < 100, treenum := treenum + 400]
-  #these all have inconsistent numbering with preceeding plots
   MiscBad <- c("10308_5", "1035_5", "1066_4", "3091_4", "5037_4", "5038_4", "5042_4",
                "5044_4", "5046_4", "5047_4", "5048_4", "5050_4", "5051_4", "5053_4",
                "5055_4", "5056_4", "7089_5")
@@ -53,9 +46,9 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
   #generate eventual plot header
   PSP_PLOTS_YR <- PSP_PLOTS_YR[Plot %in% PSP_PLOTS$Plot, .(Plot, RemeasID, MeasYr, measNum)]
 
-  #standardize
-  PSP_TREE_YIMO[, DBH := dbh/10] #dbh is measured in mm - convert to cm
-  PSP_PLOTS[, PlotSize := PlotSize/10000] # convert square metres to hectares
+  # Standardize DBH and PlotSize
+  PSP_TREE_YIMO[, DBH := dbh / 10]
+  PSP_PLOTS[, PlotSize := PlotSize / 10000]
 
   PSP_TREE_YIMO <- PSP_TREE_YIMO[, .(RemeasID, treenum, species, DBH, Plot, MeasNum)]
   # internal standardization of DBH (min DBH was 5.1 cm except for plots established in 1987,
@@ -63,8 +56,7 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
   #to simplify, remove all trees under 5.1 cm DBH
   PSP_TREE_YIMO <- PSP_TREE_YIMO[DBH > 5.0]
 
-  # Edited DBH outliers believed to be typos (Parvin added this part)
-  # Add MeasYr column for use in correction
+  # DBH corrections
   PSP_TREE_YIMO <- PSP_TREE_YIMO[PSP_PLOTS_YR[, .(RemeasID, MeasYr)], on = "RemeasID"]
   PSP_TREE_YIMO <- PSP_TREE_YIMO %>%
     mutate(DBH = case_when(
@@ -73,10 +65,10 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
       Plot == 2057  & treenum == 197 & DBH == 120.8 & MeasYr == 2011 ~ 20.8,
       Plot == 2063  & treenum == 25  & DBH == 116.9 & MeasYr == 2011 ~ 16.9,
       Plot == 38040 & treenum == 492 & DBH == 221.4 & MeasYr == 2010 ~ 21.4,
-      TRUE ~ DBH  # Keep DBH unchanged if no condition is met
+      TRUE ~ DBH
     ))
 
-  #join with measurement year
+  # Join plot measurements
   PSP_PLOTS <- PSP_PLOTS[, .(Plot, EstabAge, EstabDate, PlotSize)]
   PSP_PLOTS <- PSP_PLOTS[PSP_PLOTS_YR, on = "Plot"]
 
@@ -91,9 +83,10 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
   #species may be unknown in NB data - but there should be no NA due to bad joins
   sppNB <- NB_PSP_Data[["LookUp_Species"]][, .(species, LatinName, CommonName)]
   PSP_TREE_YIMO[is.na(species), species := 999] #coded as unknown in table
-  sppEquivPrep <- sppEquiv[, .(Latin_full, PSP)]
+
+  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "NB_forestry", "Latin_full", "PSP")])
   PSP_TREE_YIMO <- sppNB[PSP_TREE_YIMO, on = c("species")]
-  PSP_TREE_YIMO <- sppEquivPrep[PSP_TREE_YIMO, on = c("Latin_full" = "LatinName")]
+  PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = c("Latin_full" = "LatinName")]
   #note that most species lack biomass equations
   PSP_TREE_YIMO[is.na(PSP)|PSP == "", PSP := CommonName]
   PSP_TREE_YIMO[, c("species", "CommonName") := NULL]
@@ -122,38 +115,20 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
            new = c("OrigPlotID1", "Latitude", "Longitude", "MeasureID", "MeasureYear"))
 
   setnames(PSP_TREE_YIMO,
-           old = c("Latin_full", "PSP", "RemeasID", "treenum", "Plot", "MeasYr"),
+           old = c("LandR", "PSP", "RemeasID", "treenum", "Plot", "MeasYr"),
            new = c("Species", "newSpeciesName", "MeasureID", "TreeNumber", "OrigPlotID1", "MeasureYear"))
+
 
   setcolorder(PSP_TREE_YIMO, c("MeasureID", "OrigPlotID1", "MeasureYear",
                                "TreeNumber", "Species", "DBH", "newSpeciesName"))
 
   plotCols <- c("MeasureID", "OrigPlotID1", "MeasureYear", "Longitude",
                 "Latitude", "PlotSize", "baseYear", "baseSA")
+
   PSP_PLOTS <- PSP_PLOTS[, .SD, .SDcol = plotCols]
 
-   # Make sure join columns are uppercase / standardized
-  sppEquiv[, NB_forestry := toupper(NB_forestry)]
-  sppEquiv <- unique(sppEquiv)
-
-  # Select only necessary columns and join
-  sppEquiv <- sppEquiv[NB_forestry != "", .SD[1], by = NB_forestry, .SDcols = c("NB_forestry",  sppEquivCol, "PSP")]
-
-  setnames(sppEquiv,
-           old = c(sppEquivCol, "PSP"),
-           new = c("Species", "newSpeciesName"))
-
-  PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = "newSpeciesName"]
-
-  PSP_TREE_YIMO[, .(NB_forestry, Species, newSpeciesName)]
-
-  PSP_TREE_YIMO[, c("i.Species","NB_forestry.1") := NULL]
-
-  # Fill missing NB_forestry with "unknown"
-  PSP_TREE_YIMO [is.na(NB_forestry) | NB_forestry== "", NB_forestry := "unknown"]
-
   PSP_TREE_YIMO <- PSP_TREE_YIMO[, .(
-     MeasureID, OrigPlotID1, MeasureYear, Species, newSpeciesName, TreeNumber,DBH
+     MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH
   )]
 
 
@@ -165,6 +140,20 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
 
   PSP_PLOTS[, source := "NB"]
   PSP_TREE_YIMO[, source := "NB"]
+
+
+  # Handle missing species in one consolidated block
+  PSP_TREE_YIMO[is.na(Species) | Species == "", Species := newSpeciesName]
+  PSP_TREE_YIMO[is.na(Species) | Species == "", Species := "unknown"]
+  PSP_TREE_YIMO[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  PSP_TREE_YIMO[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown species
+  PSP_TREE_YIMO[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(
     "plotHeaderData" = PSP_PLOTS,

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -132,28 +132,30 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
                 "Latitude", "PlotSize", "baseYear", "baseSA")
   PSP_PLOTS <- PSP_PLOTS[, .SD, .SDcol = plotCols]
 
-  # -------------------------------------------------------------------------------------------------
-  #Parvin added this part
-  # Make sure join columns are uppercase / standardized
+   # Make sure join columns are uppercase / standardized
   sppEquiv[, NB_forestry := toupper(NB_forestry)]
+  sppEquiv <- unique(sppEquiv)
+
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[NB_forestry != "", .SD[1], by = NB_forestry, .SDcols = c("NB_forestry",  sppEquivCol, "PSP")]
+
   setnames(sppEquiv,
            old = c(sppEquivCol, "PSP"),
            new = c("Species", "newSpeciesName"))
 
-  sppEquiv[, newSpeciesName := tolower(newSpeciesName)]
-  PSP_TREE_YIMO[, newSpeciesName := tolower(newSpeciesName)]
-
-  # Remove empty rows and keep unique NB_forestry
-  sppEquiv <- sppEquiv[NB_forestry != "", .SD[1], by = NB_forestry]
-  sppEquiv <- sppEquiv[, .SD, .SDcols = c("NB_forestry", "Species", "newSpeciesName")]
-
-  # Join PSP_TREE_YIMO with sppEquiv by newSpeciesName
-  PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = c("newSpeciesName"), allow.cartesian = TRUE]
+  PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = "newSpeciesName"]
 
   PSP_TREE_YIMO[, .(NB_forestry, Species, newSpeciesName)]
+
+  PSP_TREE_YIMO[, NB_forestry.1 := NULL]
   PSP_TREE_YIMO[, i.Species := NULL]
 
-  # -------------------------------------------------------------------------------------------------------
+  PSP_TREE_YIMO <- PSP_TREE_YIMO[!(is.na(NB_forestry) | NB_forestry == "" | NB_forestry == "unknown")]
+
+  PSP_TREE_YIMO <- PSP_TREE_YIMO[, .(
+    NB_forestry, MeasureID, OrigPlotID1, MeasureYear,TreeNumber,Species,DBH,newSpeciesName
+  )]
+
 
   #assign NB
   PSP_TREE_YIMO[, OrigPlotID1 := paste0("NBPSP_", OrigPlotID1)]

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -11,11 +11,16 @@ globalVariables(c(
 #' @param NB_PSP_Data list of data tables resulting from `prepInputsNBPSP`
 #' @param sppEquiv species equivalencies table with column `Latin-full`
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of standardized plot and tree data.tables
 #'
 #' @export
 #' @importFrom data.table set setcolorder
-dataPurification_NBPSP <- function(NB_PSP_Data, sppEquiv = LandR::sppEquivalencies_CA) {
+dataPurification_NBPSP <- function(NB_PSP_Data,
+                                   sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
 
   PSP_PLOTS <- NB_PSP_Data[["PSP_PLOTS"]]
   PSP_PLOTS_YR <- NB_PSP_Data[["PSP_PLOTS_YR"]]
@@ -31,16 +36,6 @@ dataPurification_NBPSP <- function(NB_PSP_Data, sppEquiv = LandR::sppEquivalenci
   PSP_PLOTS_YR <- PSP_PLOTS_YR[!RemeasID %in% "10405_4",]
   PSP_TREE_YIMO <- PSP_TREE_YIMO[!RemeasID %in% "10405_4"]
 
-  #no treated plots
-  #TODO: investigate what YearTreated actually means.
-  # PSP_PLOTS <- PSP_PLOTS[YearTreated == 0]
-  #Per the manual:
-  # year-treated Year of silviculture treatment for managed stand
-  # a few YIMO are 0, the majority are 2000
-  # however the YIMO are not supposed to be managed, furthermore:
-  # silv_ID Link to management prescription for managed stands
-  # these stands are all silv_ID 0
-
   #no dead trees
   PSP_TREE_YIMO <- PSP_TREE_YIMO[!cause %in% 1:9]
   # has age
@@ -55,7 +50,7 @@ dataPurification_NBPSP <- function(NB_PSP_Data, sppEquiv = LandR::sppEquivalenci
                "5055_4", "5056_4", "7089_5")
   PSP_TREE_YIMO <- PSP_TREE_YIMO[!RemeasID %in% MiscBad]
 
-    #generate eventual plot header
+  #generate eventual plot header
   PSP_PLOTS_YR <- PSP_PLOTS_YR[Plot %in% PSP_PLOTS$Plot, .(Plot, RemeasID, MeasYr, measNum)]
 
   #standardize
@@ -137,6 +132,29 @@ dataPurification_NBPSP <- function(NB_PSP_Data, sppEquiv = LandR::sppEquivalenci
                 "Latitude", "PlotSize", "baseYear", "baseSA")
   PSP_PLOTS <- PSP_PLOTS[, .SD, .SDcol = plotCols]
 
+  # -------------------------------------------------------------------------------------------------
+  #Parvin added this part
+  # Make sure join columns are uppercase / standardized
+  sppEquiv[, NB_forestry := toupper(NB_forestry)]
+  setnames(sppEquiv,
+           old = c(sppEquivCol, "PSP"),
+           new = c("Species", "newSpeciesName"))
+
+  sppEquiv[, newSpeciesName := tolower(newSpeciesName)]
+  PSP_TREE_YIMO[, newSpeciesName := tolower(newSpeciesName)]
+
+  # Remove empty rows and keep unique NB_forestry
+  sppEquiv <- sppEquiv[NB_forestry != "", .SD[1], by = NB_forestry]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("NB_forestry", "Species", "newSpeciesName")]
+
+  # Join PSP_TREE_YIMO with sppEquiv by newSpeciesName
+  PSP_TREE_YIMO <- sppEquiv[PSP_TREE_YIMO, on = c("newSpeciesName"), allow.cartesian = TRUE]
+
+  PSP_TREE_YIMO[, .(NB_forestry, Species, newSpeciesName)]
+  PSP_TREE_YIMO[, i.Species := NULL]
+
+  # -------------------------------------------------------------------------------------------------------
+
   #assign NB
   PSP_TREE_YIMO[, OrigPlotID1 := paste0("NBPSP_", OrigPlotID1)]
   PSP_PLOTS[, OrigPlotID1 := paste0("NBPSP_", OrigPlotID1)]
@@ -176,9 +194,9 @@ prepInputsNBPSP <- function(dPath) {
                           fun = "fread",
                           destinationPath = dPath)
   pspNBloc <- prepInputs(targetFile = "PSP_LOC_LAT_LONG.txt",
-                        url = "https://drive.google.com/file/d/1lBbuXuVIQ0QkO80a6DnxQlXm8wwtWHmN/view?usp=drive_link",
-                        destinationPath = dPath,
-                        fun = "fread")
+                         url = "https://drive.google.com/file/d/1lBbuXuVIQ0QkO80a6DnxQlXm8wwtWHmN/view?usp=drive_link",
+                         destinationPath = dPath,
+                         fun = "fread")
 
   lookupSpecies <- prepInputs(targetFile = "LookUp_Species_NB.txt",
                               url = "https://drive.google.com/file/d/1DBeZ5LOk8Io3Zp2uSeYCDveMsLCy7zei/view?usp=drive_link",

--- a/R/NewBrunswickPSP.R
+++ b/R/NewBrunswickPSP.R
@@ -120,8 +120,9 @@ dataPurification_NBPSP <- function(NB_PSP_Data,
 
   # Check
   PSP_TREE_YIMO[, .(PSP, Species)]
-  PSP_TREE_YIMO[is.na(Species), Species := "unknown"]
 
+  PSP_TREE_YIMO[is.na(Species)| Species == "", Species := "unknown"]
+  PSP_TREE_YIMO[is.na(PSP) | PSP == "", PSP := "unknown"]
 
   plotCols <- c("MeasureID", "OrigPlotID1", "MeasureYear", "Longitude",
                 "Latitude", "PlotSize", "baseYear", "baseSA")

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -13,19 +13,24 @@ globalVariables(c(
   "TreeRenumber", "TreeStatusCode", "unifiedAge", "VisitTypeName", "Width"
 ))
 
-#' standardize and treat the Ontario PSP data
+
+#' #' Standardize and Treat the Ontario PSP Data
 #'
-#' @param ONPSPlist list of relevant plots
-#' @param sppEquiv table of species names - see `LandR::sppEquiv`-
-#' must have column 'latin' and 'PSP'
+#' This function cleans and standardizes Ontario PSP data, including tree and plot data.
+#' Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param ONPSPlist A list of relevant PSP plots and associated data.tables.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#'                 Must include columns `'Latin'` and `'PSP'`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table copy data.table set setcolorder setkey dcast
+
 #'
 dataPurification_ONPSP <- function(ONPSPlist,
                                    sppEquiv = LandR::sppEquivalencies_CA,

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -29,7 +29,7 @@ globalVariables(c(
 #'
 dataPurification_ONPSP <- function(ONPSPlist,
                                    sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
   ## TODO: review excludeAllObs - I dont' think we exclude anything at the moment
 
   ##### Location ####
@@ -102,7 +102,7 @@ dataPurification_ONPSP <- function(ONPSPlist,
 
   ##### height#####
   treeMsr <- treeMsr[, .SD, .SDcol = colnames(treeMsr)[!colnames(treeMsr) %in%
-    c("LocAzi", "Radius", "LocDist", "Width", "Length")]]
+                                                         c("LocAzi", "Radius", "LocDist", "Width", "Length")]]
   treeHeight <- ONPSPlist[["tblHt"]]
   treeMsr <- treeHeight[, .(TreeMsrKey, HtTot)][treeMsr, on = c("TreeMsrKey")]
   rm(treeHeight)
@@ -171,8 +171,8 @@ dataPurification_ONPSP <- function(ONPSPlist,
   # cast the multiple age measurements - there may be a way to drop the NA columns
 
   treeAges <- dcast(treeAges, AgeTreeKey + GrowthPlotNum + FieldSeasonYear +
-    TreeNum + CrownClassCode + DBH ~ ageMethod,
-  value.var = c("FieldAge", "OfficeAge"), fun.aggregate = mean, drop = c(TRUE)
+                      TreeNum + CrownClassCode + DBH ~ ageMethod,
+                    value.var = c("FieldAge", "OfficeAge"), fun.aggregate = mean, drop = c(TRUE)
   )
   # correct obvious mistakes
   treeAges[AgeTreeKey == 80459, OfficeAge_Base := 73] # they are clearly missing the 7 - age is 3 otherwise
@@ -268,11 +268,10 @@ dataPurification_ONPSP <- function(ONPSPlist,
   # correct growthPlot numbers using factor of growthPlot_treeNumber. Confirm rerenumber, oldNumber, treeNumber
 
   # Standardize sppEquiv
-  sppEquiv[, ON_forestry := toupper(ON_forestry)]
   #standardize species names - for biomass estimation
-  sppEquiv <- sppEquiv[, .SD, .SDcols = c("Latin_full", "PSP", "ON_forestry", sppEquivCol)]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("ON_forestry", sppEquivCol)]
 
-  setnames(sppEquiv, old = c("Latin_full", "PSP"), new = c("fullGenusSpec", "newSpeciesName"))
+  setnames(sppEquiv, old = c(sppEquivCol), new = c("fullGenusSpec"))
   sppEquiv <- unique(sppEquiv)
 
   # fix a few codings to match PSP - there is no biomass equation for species-specific willow anyway
@@ -286,18 +285,17 @@ dataPurification_ONPSP <- function(ONPSPlist,
 
   tree <- sppEquiv[tree, on = ("fullGenusSpec")]
 
-  setnames(tree, old = "LandR", new = "Species")
+  setnames(tree, old = c("fullGenusSpec", "ON_forestry") , new = c("Species", "PSP"))
 
-  tree[newSpeciesName == "Unknown Hardwood", newSpeciesName := "unknown hardwood"]
-
-  tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := tolower(SpecCommon)]
+  tree[Species == "Unknown Hardwood", Species := "unknown hardwood"]
+  tree[is.na(Species), Species := "unknown"]
 
   tree[, c("OriginName", "fullGenusSpec", "OrigTreeNum") := NULL]
 
   # # Fill missing Species with original newSpeciesName
   # tree[is.na(Species), Species := newSpeciesName]
 
-   #### final clean up of Plot ####
+  #### final clean up of Plot ####
   rm(standInfoTreatment, standInfoHeader, Package)
 
 
@@ -359,7 +357,7 @@ dataPurification_ONPSP <- function(ONPSPlist,
   tree[, OrigPlotID1 := as.factor(paste0("ONPSP_", OrigPlotID1))]
   plotData[, Datum := as.factor(Datum)]
 
-  tree <- tree[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)]
+  tree <- tree[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height)]
 
   setkey(plotData, OrigPlotID1, MeasureID, MeasureYear)
   setcolorder(plotData)
@@ -367,18 +365,6 @@ dataPurification_ONPSP <- function(ONPSPlist,
   plotData[, source := "ON"]
   tree[, source := "ON"]
 
-  # Handle missing species in one consolidated block
-  tree[is.na(Species) | Species == "", Species := newSpeciesName]
-  tree[is.na(Species) | Species == "", Species := "unknown"]
-  tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown vs real in Species
-  tree[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(
     plotHeaderData = plotData,

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -272,9 +272,6 @@ dataPurification_ONPSP <- function(ONPSPlist,
   #standardize species names - for biomass estimation
   sppEquiv <- sppEquiv[, .SD, .SDcols = c("Latin_full", "PSP", "ON_forestry", sppEquivCol)]
 
-  sppEquiv <- sppEquiv[!(is.na(ON_forestry) | ON_forestry == "" | ON_forestry == "unknown")]
-
-
   setnames(sppEquiv, old = c("Latin_full", "PSP"), new = c("fullGenusSpec", "newSpeciesName"))
   sppEquiv <- unique(sppEquiv)
 
@@ -300,9 +297,8 @@ dataPurification_ONPSP <- function(ONPSPlist,
   # Fill missing Species with original newSpeciesName
   tree[is.na(Species), Species := newSpeciesName]
 
-  tree <- tree[!(is.na(ON_forestry) | ON_forestry == "" | ON_forestry == "unknown")]
   # Fill missing ON_forestry with "unknown"
-  # tree[is.na(ON_forestry) | ON_forestry == "", ON_forestry := "unknown"]
+  tree[is.na(ON_forestry) | ON_forestry == "", ON_forestry := "unknown"]
 
   #### final clean up of Plot ####
   rm(standInfoTreatment, standInfoHeader, Package)
@@ -366,8 +362,7 @@ dataPurification_ONPSP <- function(ONPSPlist,
   tree[, OrigPlotID1 := as.factor(paste0("ONPSP_", OrigPlotID1))]
   plotData[, Datum := as.factor(Datum)]
 
-  setkey(tree, ON_forestry, Species, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, DBH, Height, newSpeciesName)
-  setcolorder(tree)
+  tree <- tree[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)]
 
   setkey(plotData, OrigPlotID1, MeasureID, MeasureYear)
   setcolorder(plotData)

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -288,12 +288,12 @@ dataPurification_ONPSP <- function(ONPSPlist,
   setnames(tree, old = c("fullGenusSpec", "ON_forestry") , new = c("Species", "PSP"))
 
   tree[Species == "Unknown Hardwood", Species := "unknown hardwood"]
-  tree[is.na(Species), Species := "unknown"]
 
-  tree[, c("OriginName", "fullGenusSpec", "OrigTreeNum") := NULL]
+  tree[, .(PSP, Species)]
+  tree[is.na(Species)| Species == "", Species := "unknown"]
+  tree[is.na(PSP) | PSP == "", PSP := "unknown"]
 
-  # # Fill missing Species with original newSpeciesName
-  # tree[is.na(Species), Species := newSpeciesName]
+  tree[, c("OriginName", "OrigTreeNum") := NULL]
 
   #### final clean up of Plot ####
   rm(standInfoTreatment, standInfoHeader, Package)

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -19,12 +19,17 @@ globalVariables(c(
 #' @param sppEquiv table of species names - see `LandR::sppEquiv`-
 #' must have column 'latin' and 'PSP'
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of plot and tree data.tables
 #'
 #' @export
 #' @importFrom data.table copy data.table set setcolorder setkey dcast
 #'
-dataPurification_ONPSP <- function(ONPSPlist, sppEquiv = LandR::sppEquivalencies_CA) {
+dataPurification_ONPSP <- function(ONPSPlist,
+                                   sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
   ## TODO: review excludeAllObs - I dont' think we exclude anything at the moment
 
   ##### Location ####

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -294,13 +294,10 @@ dataPurification_ONPSP <- function(ONPSPlist,
 
   tree[, c("OriginName", "fullGenusSpec", "OrigTreeNum") := NULL]
 
-  # Fill missing Species with original newSpeciesName
-  tree[is.na(Species), Species := newSpeciesName]
+  # # Fill missing Species with original newSpeciesName
+  # tree[is.na(Species), Species := newSpeciesName]
 
-  # Fill missing ON_forestry with "unknown"
-  tree[is.na(ON_forestry) | ON_forestry == "", ON_forestry := "unknown"]
-
-  #### final clean up of Plot ####
+   #### final clean up of Plot ####
   rm(standInfoTreatment, standInfoHeader, Package)
 
 
@@ -369,6 +366,19 @@ dataPurification_ONPSP <- function(ONPSPlist,
 
   plotData[, source := "ON"]
   tree[, source := "ON"]
+
+  # Handle missing species in one consolidated block
+  tree[is.na(Species) | Species == "", Species := newSpeciesName]
+  tree[is.na(Species) | Species == "", Species := "unknown"]
+  tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown vs real in Species
+  tree[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(
     plotHeaderData = plotData,

--- a/R/OntarioPSP.R
+++ b/R/OntarioPSP.R
@@ -267,9 +267,15 @@ dataPurification_ONPSP <- function(ONPSPlist,
   setnames(tree, "TreeKey", "TreeNumber")
   # correct growthPlot numbers using factor of growthPlot_treeNumber. Confirm rerenumber, oldNumber, treeNumber
 
-  # standardize species names - for biomass estimation
-  sppEquiv <- sppEquiv[, .(Latin_full, PSP)]
-  setnames(sppEquiv, new = c("fullGenusSpec", "newSpeciesName"))
+  # Standardize sppEquiv
+  sppEquiv[, ON_forestry := toupper(ON_forestry)]
+  #standardize species names - for biomass estimation
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("Latin_full", "PSP", "ON_forestry", sppEquivCol)]
+
+  sppEquiv <- sppEquiv[!(is.na(ON_forestry) | ON_forestry == "" | ON_forestry == "unknown")]
+
+
+  setnames(sppEquiv, old = c("Latin_full", "PSP"), new = c("fullGenusSpec", "newSpeciesName"))
   sppEquiv <- unique(sppEquiv)
 
   # fix a few codings to match PSP - there is no biomass equation for species-specific willow anyway
@@ -280,11 +286,23 @@ dataPurification_ONPSP <- function(ONPSPlist,
   # this seems most likely, among populus spp with biomass equations
   tree[fullGenusSpec %in% c("Populus x", "Populus sp"), fullGenusSpec := "Populus balsamifera"]
   tree[fullGenusSpec == "Acer saccharum ssp. nigrum", fullGenusSpec := "Acer saccharum"]
+
   tree <- sppEquiv[tree, on = ("fullGenusSpec")]
-  tree[SpecCommon == "Unknown Hardwood", newSpeciesName := "unknown hardwood"]
+
+  setnames(tree, old = "LandR", new = "Species")
+
+  tree[newSpeciesName == "Unknown Hardwood", newSpeciesName := "unknown hardwood"]
+
   tree[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := tolower(SpecCommon)]
+
   tree[, c("OriginName", "fullGenusSpec", "OrigTreeNum") := NULL]
 
+  # Fill missing Species with original newSpeciesName
+  tree[is.na(Species), Species := newSpeciesName]
+
+  tree <- tree[!(is.na(ON_forestry) | ON_forestry == "" | ON_forestry == "unknown")]
+  # Fill missing ON_forestry with "unknown"
+  # tree[is.na(ON_forestry) | ON_forestry == "", ON_forestry := "unknown"]
 
   #### final clean up of Plot ####
   rm(standInfoTreatment, standInfoHeader, Package)
@@ -337,7 +355,7 @@ dataPurification_ONPSP <- function(ONPSPlist,
   # use TreeNumber - MeasureID will come from paste of PlotName_FieldSeasonYear
 
   tree[, c("CrownClassCode", "TreeHeaderKey") := NULL]
-  setnames(tree, c("HtTot", "FieldSeasonYear", "PlotName", "SpecCommon"), c("Height", "MeasureYear", "OrigPlotID1", "Species"))
+  setnames(tree, c("HtTot", "FieldSeasonYear", "PlotName"), c("Height", "MeasureYear", "OrigPlotID1"))
   tree <- tree[plotData[, .(MeasureYear, OrigPlotID1, MeasureID)], on = c("OrigPlotID1", "MeasureYear")]
   # some tree measurements wil be dropped as the plots were filtered out
 
@@ -348,7 +366,7 @@ dataPurification_ONPSP <- function(ONPSPlist,
   tree[, OrigPlotID1 := as.factor(paste0("ONPSP_", OrigPlotID1))]
   plotData[, Datum := as.factor(Datum)]
 
-  setkey(tree, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, DBH, Height, newSpeciesName)
+  setkey(tree, ON_forestry, Species, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, DBH, Height, newSpeciesName)
   setcolorder(tree)
 
   setkey(plotData, OrigPlotID1, MeasureID, MeasureYear)

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -196,7 +196,8 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
            new = c("OrigPlotID1", "MeasureID", "Elevation", "baseSA", "Latitude", "Longitude"))
 
 
-  trees <- trees[!(is.na(QCPSP) | QCPSP == "" | QCPSP == "unknown")]
+  # Fill missing QCPSP with "unknown"
+  trees[is.na(QCPSP) | QCPSP== "", QCPSP := "unknown"]
 
   trees[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
                                              paste0("QCPSP_", OrigPlotID1))]
@@ -207,12 +208,13 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   #some plots do not have trees remaining
   PLACETTE_FINAL <- PLACETTE_FINAL[MeasureID %in% trees$MeasureID]
 
-  setkey(trees, MeasureID, OrigPlotID1, MeasureYear,
-         TreeNumber, Species, DBH, Height, newSpeciesName)
+  setkey(trees, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
   setcolorder(trees)
 
   setkey(PLACETTE_FINAL, OrigPlotID1, MeasureID, MeasureYear)
   setcolorder(PLACETTE_FINAL)
+
+  trees[, QCPSP := NULL]
 
   PLACETTE_FINAL[, source := "QC"]
   trees[, source := "QC"]

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -10,17 +10,27 @@ globalVariables(c(
 ))
 
 
-#' standardize and treat the QUEBEC PSP data
-
-#' @param QuebecPSP list of PSP data.tables obtained via `prepInputsQCPSP`
-#' @param codesToExclude TODO: eventually add codes for pest disturbance if applicable
-#' @param excludeAllObs assuming codesToExclude is not NULL, exclude these obs or prior ones too
-#' @param sppEquiv table of species names - see `LandR::sppEquiv`
-#' @return a list of standardized plot and tree data.tables
+#' Standardize and Treat the Quebec PSP Data
+#'
+#' This function cleans and standardizes the Quebec PSP data, including tree and plot data.
+#' Species names can be standardized using a species equivalency table.
+#'
+#' @param QuebecPSP A list of `data.table`s containing raw PSP data obtained via `prepInputsQCPSP`.
+#' @param codesToExclude Character vector of damage or pest disturbance codes to exclude from measurements.
+#'                       Currently placeholder, update if applicable.
+#' @param excludeAllObs Logical. If `TRUE` and `codesToExclude` is not `NULL`, all prior and future
+#'                       observations of trees with these codes will be removed.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
+#'
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table setnames
 #' @importFrom bit64 as.integer64
+
 dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllObs = TRUE,
                                    sppEquiv = LandR::sppEquivalencies_CA,
                                    sppEquivCol = "Latin_full") {

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -23,7 +23,7 @@ globalVariables(c(
 #' @importFrom bit64 as.integer64
 dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllObs = TRUE,
                                    sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
  #DENDRO_ARBRES_ETUDES is a subset of DENDRO_ARBRES with additional information (e.g. age, height)
   PLACETTE <- QuebecPSP[["PLACETTE"]]
   PLACETTE_MES <- QuebecPSP[["PLACETTE_MES"]]
@@ -177,23 +177,25 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
 
   #standardize species
   #unique because some species have multiple rows (e.g. due to common name)
-  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "QCPSP", "PSP")])
-  setnames(sppEquiv, old = c("QCPSP", "PSP"), new = c("ESSENCE", "newSpeciesName"))
+  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "QCPSP")])
   # Keep unique rows only
   sppEquiv <- unique(sppEquiv)
-  trees <- sppEquiv[trees, on = c("ESSENCE")]
+  trees <- sppEquiv[trees, on = c(QCPSP = "ESSENCE")]
 
   #ensure all measurements have associated plots
   trees <- trees[PLACETTE_FINAL[, .(ID_PE_MES, MeasureYear)], on = "ID_PE_MES"]
-  trees <- trees[, .(ID_PE, ID_PE_MES, NO_ARBRE, MeasureYear, LandR,
-                     ESSENCE, DHP, HAUT_ARBRE, newSpeciesName)]
   setnames(trees,
-           old = c("LandR","ESSENCE", "DHP", "HAUT_ARBRE", "NO_ARBRE", "ID_PE", "ID_PE_MES"),
-           new = c("Species","QCPSP", "DBH", "Height", "TreeNumber", "OrigPlotID1", "MeasureID"))
+           old = c(sppEquivCol,"QCPSP", "DHP", "HAUT_ARBRE", "NO_ARBRE", "ID_PE", "ID_PE_MES"),
+           new = c("Species","PSP", "DBH", "Height", "TreeNumber", "OrigPlotID1", "MeasureID"))
 
   setnames(PLACETTE_FINAL,
            old = c("ID_PE", "ID_PE_MES", "ALTITUDE", "baseStandAge", "LATITUDE", "LONGITUDE"),
            new = c("OrigPlotID1", "MeasureID", "Elevation", "baseSA", "Latitude", "Longitude"))
+
+  # Check
+  trees[, .(PSP, Species)]
+  trees[is.na(Species), Species := "unknown"]
+
 
   trees[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
                                              paste0("QCPSP_", OrigPlotID1))]
@@ -204,30 +206,15 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   #some plots do not have trees remaining
   PLACETTE_FINAL <- PLACETTE_FINAL[MeasureID %in% trees$MeasureID]
 
-  setkey(trees, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
-  setcolorder(trees)
+  trees <- trees[, .(
+    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height
+  )]
 
-  setkey(PLACETTE_FINAL, OrigPlotID1, MeasureID, MeasureYear)
-  setcolorder(PLACETTE_FINAL)
-
-  trees[, QCPSP := NULL]
+  PLACETTE_FINAL <- PLACETTE_FINAL[, .(
+    MeasureID, OrigPlotID1, MeasureYear)]
 
   PLACETTE_FINAL[, source := "QC"]
   trees[, source := "QC"]
-
-
-  # Handle missing species in one consolidated block
-  trees[is.na(Species) | Species == "", Species := newSpeciesName]
-  trees[is.na(Species) | Species == "", Species := "unknown"]
-  trees[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  trees[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown vs real in Species
-  trees[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(plotHeaderData = PLACETTE_FINAL,
               treeData = trees))

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -195,10 +195,6 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
            old = c("ID_PE", "ID_PE_MES", "ALTITUDE", "baseStandAge", "LATITUDE", "LONGITUDE"),
            new = c("OrigPlotID1", "MeasureID", "Elevation", "baseSA", "Latitude", "Longitude"))
 
-
-  # Fill missing QCPSP with "unknown"
-  trees[is.na(QCPSP) | QCPSP== "", QCPSP := "unknown"]
-
   trees[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
                                              paste0("QCPSP_", OrigPlotID1))]
   PLACETTE_FINAL[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
@@ -219,6 +215,19 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   PLACETTE_FINAL[, source := "QC"]
   trees[, source := "QC"]
 
+
+  # Handle missing species in one consolidated block
+  trees[is.na(Species) | Species == "", Species := newSpeciesName]
+  trees[is.na(Species) | Species == "", Species := "unknown"]
+  trees[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  trees[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown vs real in Species
+  trees[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(plotHeaderData = PLACETTE_FINAL,
               treeData = trees))

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -22,7 +22,8 @@ globalVariables(c(
 #' @importFrom data.table setnames
 #' @importFrom bit64 as.integer64
 dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllObs = TRUE,
-                                   sppEquiv = LandR::sppEquivalencies_CA) {
+                                   sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
  #DENDRO_ARBRES_ETUDES is a subset of DENDRO_ARBRES with additional information (e.g. age, height)
   PLACETTE <- QuebecPSP[["PLACETTE"]]
   PLACETTE_MES <- QuebecPSP[["PLACETTE_MES"]]
@@ -161,11 +162,6 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   PLACETTE_FINAL <- standAge[PLACETTE_FINAL, on = c("ID_PE")]
   PLACETTE_FINAL <- PLACETTE_FINAL[!is.na(baseStandAge)]
 
-  #standardize species
-  sppEquiv <- unique(sppEquiv[, .(QCPSP, PSP)])#unique because some species have multiple rows (e.g. due to common name)
-  setnames(sppEquiv, old = c("QCPSP", "PSP"), new = c("ESSENCE", "newSpeciesName"))
-  # DENDRO_ARBRES_ETUDES <- sppEquiv[DENDRO_ARBRES_ETUDES, on = c("ESSENCE")]
-  trees <- sppEquiv[trees, on = c("ESSENCE")]
   #standardize attribute names
   PLACETTE_FINAL <- PLACETTE_FINAL[, .(ID_PE, ID_PE_MES, MeasureYear, ALTITUDE,
                                        LATITUDE, LONGITUDE, baseStandAge, baseYear)]
@@ -179,26 +175,37 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   trees[, DHP := DHP/10] #from millimetre to centimetre
   trees[, HAUT_ARBRE := HAUT_ARBRE/10] #from decimetre to metre
 
+  #standardize species
+  #unique because some species have multiple rows (e.g. due to common name)
+  sppEquiv <- unique(sppEquiv[, .SD, .SDcols = c(sppEquivCol, "QCPSP", "PSP")])
+  setnames(sppEquiv, old = c("QCPSP", "PSP"), new = c("ESSENCE", "newSpeciesName"))
+  # Keep unique rows only
+  sppEquiv <- unique(sppEquiv)
+  trees <- sppEquiv[trees, on = c("ESSENCE")]
+
   #ensure all measurements have associated plots
   trees <- trees[PLACETTE_FINAL[, .(ID_PE_MES, MeasureYear)], on = "ID_PE_MES"]
-  trees <- trees[, .(ID_PE, ID_PE_MES, NO_ARBRE, MeasureYear,
+  trees <- trees[, .(ID_PE, ID_PE_MES, NO_ARBRE, MeasureYear, LandR,
                      ESSENCE, DHP, HAUT_ARBRE, newSpeciesName)]
   setnames(trees,
-           old = c("ESSENCE", "DHP", "HAUT_ARBRE", "NO_ARBRE", "ID_PE", "ID_PE_MES"),
-           new = c("Species", "DBH", "Height", "TreeNumber", "OrigPlotID1", "MeasureID"))
+           old = c("LandR","ESSENCE", "DHP", "HAUT_ARBRE", "NO_ARBRE", "ID_PE", "ID_PE_MES"),
+           new = c("Species","QCPSP", "DBH", "Height", "TreeNumber", "OrigPlotID1", "MeasureID"))
 
   setnames(PLACETTE_FINAL,
            old = c("ID_PE", "ID_PE_MES", "ALTITUDE", "baseStandAge", "LATITUDE", "LONGITUDE"),
            new = c("OrigPlotID1", "MeasureID", "Elevation", "baseSA", "Latitude", "Longitude"))
+
+
+  trees <- trees[!(is.na(QCPSP) | QCPSP == "" | QCPSP == "unknown")]
 
   trees[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
                                              paste0("QCPSP_", OrigPlotID1))]
   PLACETTE_FINAL[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
                                                       paste0("QCPSP_", OrigPlotID1))]
 
+
   #some plots do not have trees remaining
   PLACETTE_FINAL <- PLACETTE_FINAL[MeasureID %in% trees$MeasureID]
-
 
   setkey(trees, MeasureID, OrigPlotID1, MeasureYear,
          TreeNumber, Species, DBH, Height, newSpeciesName)

--- a/R/QuebecPSP.R
+++ b/R/QuebecPSP.R
@@ -194,7 +194,9 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
 
   # Check
   trees[, .(PSP, Species)]
-  trees[is.na(Species), Species := "unknown"]
+
+  trees[is.na(Species)| Species == "", Species := "unknown"]
+  trees[is.na(PSP) | PSP == "", PSP := "unknown"]
 
 
   trees[, c("MeasureID", "OrigPlotID1") := .(paste0("QCPSP_", MeasureID),
@@ -206,12 +208,16 @@ dataPurification_QCPSP <- function(QuebecPSP, codesToExclude = NULL, excludeAllO
   #some plots do not have trees remaining
   PLACETTE_FINAL <- PLACETTE_FINAL[MeasureID %in% trees$MeasureID]
 
+  setkey(trees, MeasureID, OrigPlotID1, MeasureYear,
+         TreeNumber, PSP, Species, DBH, Height)
+  setcolorder(trees)
+
+  setkey(PLACETTE_FINAL, OrigPlotID1, MeasureID, MeasureYear)
+  setcolorder(PLACETTE_FINAL)
+
   trees <- trees[, .(
     MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height
   )]
-
-  PLACETTE_FINAL <- PLACETTE_FINAL[, .(
-    MeasureID, OrigPlotID1, MeasureYear)]
 
   PLACETTE_FINAL[, source := "QC"]
   trees[, source := "QC"]

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -3,7 +3,7 @@ globalVariables(c(
   "CONDITION_CODE3", "CROWN_CLASS", "dbh", "DBH", "Easting", "height",
   "Height", "HEIGHT", "IsBad", "MeasureID", "MeausreYear", "MORTALITY",
   "NofTrees", "Northing", "OFFICE_ERROR", "OrigPlotID1", "OrigPlotID2",
-  "PLOT_ID", "PLOT_SIZE", "PlotSize", "SK_Forestry", "species", "Species", "SPECIES",
+  "PLOT_ID", "PLOT_SIZE", "PlotSize", "SK_forestry", "species", "Species", "SPECIES",
   "TOTAL_AGE", "TREE_NO", "TREE_STATUS", "treeAge", "TreeNumber",
   "YEAR", "Z13nad83_e", "Z13nad83_n", "Zone"
 ))
@@ -31,7 +31,7 @@ globalVariables(c(
 dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
                                    treeDataRaw, codesToExclude = NULL, excludeAllObs = TRUE
                                    , sppEquiv = LandR::sppEquivalencies_CA,
-                                   sppEquivCol = "LandR") {
+                                   sppEquivCol = "Latin_full") {
 
   # get rid of artifical trees - plots where the distribution of trees/DBH/species were modelled
   treeDataRaw[, isArtificial := OFFICE_ERROR == "Artificial Tree", ]
@@ -135,40 +135,20 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
                            Latitude = NA, Zone, Easting, Northing, PlotSize, baseYear, baseSA
   )]
 
-  # ------------------------- capitalize because of inconsistencies through time  ----------------------------
-  # Uppercase to standardize (Parvin added this part)
-  treeData[, Species := toupper(Species)]
-  sppEquiv[, SK_Forestry := toupper(SK_Forestry)]
-
+  # Standardize
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[SK_forestry != "", .SD, .SDcols = c("SK_forestry", sppEquivCol)]
   # Keep unique rows only
   sppEquiv <- unique(sppEquiv)
 
-  # Select only necessary columns and join
-  sppEquiv <- sppEquiv[SK_Forestry != "", .SD[1], by = SK_Forestry , .SDcols = c("SK_Forestry", sppEquivCol, "PSP")]
-  treeData <- sppEquiv[treeData, on = .(SK_Forestry  = Species)]
+  treeData <- sppEquiv[treeData, on = .(SK_forestry  = Species)]
 
-  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+  setnames(treeData, old = c(SK_forestry, sppEquivCol), new = c("PSP", "Species"))
 
-  treeData[
-    ,
-    `:=`(
-      Species = fifelse(SK_Forestry == "TA" & (is.na(Species) | Species == ""), "Popu_tre", Species),
-      newSpeciesName = fifelse(
-        SK_Forestry == "TA" & (is.na(newSpeciesName) | newSpeciesName == ""), "trembling aspen",
-        fifelse(SK_Forestry == "BS" & (is.na(newSpeciesName) | newSpeciesName == ""), "black spruce",
-                fifelse(SK_Forestry == "WS" & (is.na(newSpeciesName) | newSpeciesName == ""), "white spruce",
-                        fifelse(SK_Forestry == "WE" & (is.na(newSpeciesName) | newSpeciesName == ""), "white elm",
-                                newSpeciesName)))
-      )
-    )
-  ]
 
   # Check
-  treeData[, .(SK_Forestry, Species, newSpeciesName)]
-  treeData[, c("SK_Forestry", "SK_Forestry.1") := NULL]
-
-  treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "SKPSP") # Need to add to pemisc
-  # -------------------------------------------------------------------------------------------------------
+  treeData[, .(PSP, Species)]
+  treeData[is.na(Species), Species := "unknown"]
 
   treeData[MeasureYear == 2044, MeasureYear := 2014] # correct obvious error
   headData[MeasureYear == 2044, MeasureYear := 2014]
@@ -205,25 +185,12 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
 
-  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
-  setcolorder(treeData)
+  treeData <- treeData[, .(
+    MeasureID, OrigPlotID1, MeasureYear, TreeNumber, PSP, Species, DBH, Height
+  )]
 
   headData[, source := "SK"]
   treeData[, source := "SK"]
-
-
-  # Handle missing species in one consolidated block
-  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
-  treeData[is.na(Species) | Species == "", Species := "unknown"]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
-  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
-
-  # Count of unknown vs real in Species
-  treeData[, .(
-    unknown_Species = sum(Species == "unknown"),
-    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
-    total_rows = .N
-  ), by = source]
 
   return(list(
     "plotHeaderData" = headData,

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -166,9 +166,10 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   # Check
   treeData[, .(SK_Forestry, Species, newSpeciesName)]
 
-  treeData[, SK_Forestry.1 := NULL]
+  # Fill missing SK_Forestry with "unknown"
+  treeData[is.na(SK_Forestry) | SK_Forestry == "", SK_Forestry := "unknown"]
 
-  treeData <- treeData[!(is.na(SK_Forestry) | SK_Forestry == "" | SK_Forestry == "unknown")]
+  treeData[, c("SK_Forestry", "SK_Forestry.1") := NULL]
 
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "SKPSP") # Need to add to pemisc
   # -------------------------------------------------------------------------------------------------------
@@ -207,6 +208,9 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   # final clean up
   treeData[Height <= 0, Height := NA]
   treeData <- treeData[!is.na(DBH) & DBH > 0]
+
+  setkey(treeData, MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, newSpeciesName, DBH, Height)
+  setcolorder(treeData)
 
   headData[, source := "SK"]
   treeData[, source := "SK"]

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -32,7 +32,7 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
                                    treeDataRaw, codesToExclude = NULL, excludeAllObs = TRUE
                                    , sppEquiv = LandR::sppEquivalencies_CA,
                                    sppEquivCol = "LandR") {
-  browser()
+
   # get rid of artifical trees - plots where the distribution of trees/DBH/species were modelled
   treeDataRaw[, isArtificial := OFFICE_ERROR == "Artificial Tree", ]
   hasArtificial <- treeDataRaw[isArtificial == TRUE, .N, .(PLOT_ID)]
@@ -136,39 +136,39 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   )]
 
   # ------------------------- capitalize because of inconsistencies through time  ----------------------------
-  # Uppercase to standardize
+  # Uppercase to standardize (Parvin added this part)
   treeData[, Species := toupper(Species)]
   sppEquiv[, SK_Forestry := toupper(SK_Forestry)]
 
-  # Keep only valid, unique SK_Forestry rows
-  sppEquiv <- sppEquiv[SK_Forestry != "", .SD[1], by = SK_Forestry]
-  sppEquiv <- sppEquiv[, .SD, .SDcols = c("SK_Forestry", sppEquivCol, "PSP")]
+  # Keep unique rows only
+  sppEquiv <- unique(sppEquiv)
 
-  # Join to treeData
-  #treeData <- sppEquiv[treeData, on = c("SK_Forestry" = "Species")]
-  treeData <- sppEquiv[SK_Forestry != "", .SD, .SDcols = c("SK_Forestry", sppEquivCol, "PSP")][
-    treeData, on = c("SK_Forestry" = "Species"), allow.cartesian = TRUE
-  ]
+  # Select only necessary columns and join
+  sppEquiv <- sppEquiv[SK_Forestry != "", .SD[1], by = SK_Forestry , .SDcols = c("SK_Forestry", sppEquivCol, "PSP")]
+  treeData <- sppEquiv[treeData, on = .(SK_Forestry  = Species)]
 
   setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
 
-  # Map SK_Forestry to Species and newSpeciesName via lookup
-  lookup <- data.table(
-    SK_Forestry = c("BF", "BP", "BS", "GA", "JP", "MM", "TA", "TL", "WB", "WE", "WS"),
-    Species = c("Abie_bal", "Popu_bap", "Pice_pun", "Fra_ash", "Pin_jun", "Acer_man",
-                "Popu_tre", "Lar_tam", "Betu_pap", "Ulmus_alb", "Pice_koy"),
-    newSpeciesName = c("balsam fir", "balsam poplar", "black spruce", "green ash",
-                       "jack pine", "manitoba maple", "trembling aspen", "tamarack larch",
-                       "white birch", "white elm", "white spruce")
-  )
-
-  # Fill Species and newSpeciesName from lookup
-  treeData <- lookup[treeData, on = "SK_Forestry"]
-
-  treeData[, c("i.Species", "i.newSpeciesName") := NULL]
+  treeData[
+    ,
+    `:=`(
+      Species = fifelse(SK_Forestry == "TA" & (is.na(Species) | Species == ""), "Popu_tre", Species),
+      newSpeciesName = fifelse(
+        SK_Forestry == "TA" & (is.na(newSpeciesName) | newSpeciesName == ""), "trembling aspen",
+        fifelse(SK_Forestry == "BS" & (is.na(newSpeciesName) | newSpeciesName == ""), "black spruce",
+                fifelse(SK_Forestry == "WS" & (is.na(newSpeciesName) | newSpeciesName == ""), "white spruce",
+                        fifelse(SK_Forestry == "WE" & (is.na(newSpeciesName) | newSpeciesName == ""), "white elm",
+                                newSpeciesName)))
+      )
+    )
+  ]
 
   # Check
   treeData[, .(SK_Forestry, Species, newSpeciesName)]
+
+  treeData[, SK_Forestry.1 := NULL]
+
+  treeData <- treeData[!(is.na(SK_Forestry) | SK_Forestry == "" | SK_Forestry == "unknown")]
 
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "SKPSP") # Need to add to pemisc
   # -------------------------------------------------------------------------------------------------------

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -8,26 +8,31 @@ globalVariables(c(
   "YEAR", "Z13nad83_e", "Z13nad83_n", "Zone"
 ))
 
-#' standardize and treat the Saskatchewan PSP data
+#' Standardize and Treat the Saskatchewan PSP Data
 #'
-#' @param SADataRaw the tree measurement csv
-#' @param plotHeaderRaw the plot header data
-#' @param measureHeaderRaw the measurement header raw
-#' @param treeDataRaw tree data
-#' @param codesToExclude damage agent codes used to filter tree data.
-#' Natural or Undetermined = 1, Disease = 2, Insect = 3, Human 4,
-#'  Wind = 5, Snow =  6, Other Trees = 7, Hail or Ice Storm = 8.
-#' Measurements with these codes will be removed
-#' @param excludeAllObs if removing observations of individual trees due to damage codes,
-#' remove all prior and future observations if `TRUE`.
+#' This function cleans and standardizes the Saskatchewan PSP data, including tree measurements,
+#' plot headers, and measurement headers. Species names can be standardized using a species equivalency table.
 #'
-#' @param sppEquiv sdfsd
-#' @param sppEquivCol sdfd
+#' @param SADataRaw A `data.frame` or `data.table` containing raw tree measurement data.
+#' @param plotHeaderRaw A `data.frame` or `data.table` containing raw plot header data.
+#' @param measureHeaderRaw A `data.frame` or `data.table` containing raw measurement header data.
+#' @param treeDataRaw A `data.frame` or `data.table` containing tree data.
+#' @param codesToExclude Character vector of damage agent codes used to filter tree data.
+#'                       Codes: Natural or Undetermined = 1, Disease = 2, Insect = 3, Human = 4,
+#'                       Wind = 5, Snow = 6, Other Trees = 7, Hail or Ice Storm = 8.
+#'                       Measurements with these codes will be removed.
+#' @param excludeAllObs Logical. If `TRUE`, all prior and future observations of trees with
+#'                       codes in `codesToExclude` are removed.
+#' @param sppEquiv A table providing species name equivalencies between the original PSP species names
+#'                 and the final standardized naming format. Default is `LandR::sppEquivalencies_CA`.
+#' @param sppEquivCol Character string. The column in `sppEquiv` that contains the standardized species names.
+#'                    Default is `"Latin_full"`.
 #'
-#' @return a list of plot and tree data.tables
+#' @return A list containing standardized `plotData` and `treeData` as `data.table`s.
 #'
 #' @export
 #' @importFrom data.table setnames setkey rbindlist
+
 dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
                                    treeDataRaw, codesToExclude = NULL, excludeAllObs = TRUE
                                    , sppEquiv = LandR::sppEquivalencies_CA,

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -3,7 +3,7 @@ globalVariables(c(
   "CONDITION_CODE3", "CROWN_CLASS", "dbh", "DBH", "Easting", "height",
   "Height", "HEIGHT", "IsBad", "MeasureID", "MeausreYear", "MORTALITY",
   "NofTrees", "Northing", "OFFICE_ERROR", "OrigPlotID1", "OrigPlotID2",
-  "PLOT_ID", "PLOT_SIZE", "PlotSize", "species", "Species", "SPECIES",
+  "PLOT_ID", "PLOT_SIZE", "PlotSize", "SK_Forestry", "species", "Species", "SPECIES",
   "TOTAL_AGE", "TREE_NO", "TREE_STATUS", "treeAge", "TreeNumber",
   "YEAR", "Z13nad83_e", "Z13nad83_n", "Zone"
 ))
@@ -21,12 +21,18 @@ globalVariables(c(
 #' @param excludeAllObs if removing observations of individual trees due to damage codes,
 #' remove all prior and future observations if `TRUE`.
 #'
+#' @param sppEquiv sdfsd
+#' @param sppEquivCol sdfd
+#'
 #' @return a list of plot and tree data.tables
 #'
 #' @export
 #' @importFrom data.table setnames setkey rbindlist
 dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
-                                   treeDataRaw, codesToExclude = NULL, excludeAllObs = TRUE) {
+                                   treeDataRaw, codesToExclude = NULL, excludeAllObs = TRUE
+                                   , sppEquiv = LandR::sppEquivalencies_CA,
+                                   sppEquivCol = "LandR") {
+  browser()
   # get rid of artifical trees - plots where the distribution of trees/DBH/species were modelled
   treeDataRaw[, isArtificial := OFFICE_ERROR == "Artificial Tree", ]
   hasArtificial <- treeDataRaw[isArtificial == TRUE, .N, .(PLOT_ID)]
@@ -62,7 +68,7 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   headData_loca <- plotHeaderRaw[PLOT_ID %in% unique(headData_SA$PLOT_ID), ][, .(PLOT_ID, Z13nad83_e, Z13nad83_n, Zone = 13)]
   setnames(headData_loca, 2:3, c("Easting", "Northing"))
   headData_SALoca <- setkey(headData_SA, PLOT_ID)[setkey(headData_loca, PLOT_ID),
-    nomatch = 0
+                                                  nomatch = 0
   ]
   headData_PS <- measureHeaderRaw[PLOT_ID %in% unique(headData_SALoca$PLOT_ID), ][, .(PLOT_ID, PLOT_SIZE)][!is.na(PLOT_SIZE), ]
   headData_PS <- unique(headData_PS, by = "PLOT_ID")
@@ -99,9 +105,9 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   #     8 8 Down snag
   #     9 9 Stump
   treeData <- treeDataRaw[is.na(TREE_STATUS) | # conservatively
-    TREE_STATUS == 0 |
-    TREE_STATUS == 1 |
-    TREE_STATUS == 2, ]
+                            TREE_STATUS == 0 |
+                            TREE_STATUS == 1 |
+                            TREE_STATUS == 2, ]
   # 2. by mortality codes
   #     Null 0
   #     Natural or Undetermined 1
@@ -125,11 +131,47 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
   treeData <- treeData[, .(MeasureID, OrigPlotID1, MeasureYear, TreeNumber, Species, DBH, Height)]
   headData <- setkey(measureidtable, OrigPlotID1)[setkey(headData, OrigPlotID1), nomatch = 0]
   headData <- headData[, .(MeasureID, OrigPlotID1, MeasureYear,
-    Longitude = NA,
-    Latitude = NA, Zone, Easting, Northing, PlotSize, baseYear, baseSA
+                           Longitude = NA,
+                           Latitude = NA, Zone, Easting, Northing, PlotSize, baseYear, baseSA
   )]
 
+  # ------------------------- capitalize because of inconsistencies through time  ----------------------------
+  # Uppercase to standardize
+  treeData[, Species := toupper(Species)]
+  sppEquiv[, SK_Forestry := toupper(SK_Forestry)]
+
+  # Keep only valid, unique SK_Forestry rows
+  sppEquiv <- sppEquiv[SK_Forestry != "", .SD[1], by = SK_Forestry]
+  sppEquiv <- sppEquiv[, .SD, .SDcols = c("SK_Forestry", sppEquivCol, "PSP")]
+
+  # Join to treeData
+  #treeData <- sppEquiv[treeData, on = c("SK_Forestry" = "Species")]
+  treeData <- sppEquiv[SK_Forestry != "", .SD, .SDcols = c("SK_Forestry", sppEquivCol, "PSP")][
+    treeData, on = c("SK_Forestry" = "Species"), allow.cartesian = TRUE
+  ]
+
+  setnames(treeData, old = c(sppEquivCol, "PSP"), new = c("Species", "newSpeciesName"))
+
+  # Map SK_Forestry to Species and newSpeciesName via lookup
+  lookup <- data.table(
+    SK_Forestry = c("BF", "BP", "BS", "GA", "JP", "MM", "TA", "TL", "WB", "WE", "WS"),
+    Species = c("Abie_bal", "Popu_bap", "Pice_pun", "Fra_ash", "Pin_jun", "Acer_man",
+                "Popu_tre", "Lar_tam", "Betu_pap", "Ulmus_alb", "Pice_koy"),
+    newSpeciesName = c("balsam fir", "balsam poplar", "black spruce", "green ash",
+                       "jack pine", "manitoba maple", "trembling aspen", "tamarack larch",
+                       "white birch", "white elm", "white spruce")
+  )
+
+  # Fill Species and newSpeciesName from lookup
+  treeData <- lookup[treeData, on = "SK_Forestry"]
+
+  treeData[, c("i.Species", "i.newSpeciesName") := NULL]
+
+  # Check
+  treeData[, .(SK_Forestry, Species, newSpeciesName)]
+
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "SKPSP") # Need to add to pemisc
+  # -------------------------------------------------------------------------------------------------------
 
   treeData[MeasureYear == 2044, MeasureYear := 2014] # correct obvious error
   headData[MeasureYear == 2044, MeasureYear := 2014]

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -165,10 +165,6 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
 
   # Check
   treeData[, .(SK_Forestry, Species, newSpeciesName)]
-
-  # Fill missing SK_Forestry with "unknown"
-  treeData[is.na(SK_Forestry) | SK_Forestry == "", SK_Forestry := "unknown"]
-
   treeData[, c("SK_Forestry", "SK_Forestry.1") := NULL]
 
   treeData <- standardizeSpeciesNames(treeData, forestInventorySource = "SKPSP") # Need to add to pemisc
@@ -214,6 +210,20 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
 
   headData[, source := "SK"]
   treeData[, source := "SK"]
+
+
+  # Handle missing species in one consolidated block
+  treeData[is.na(Species) | Species == "", Species := newSpeciesName]
+  treeData[is.na(Species) | Species == "", Species := "unknown"]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := Species]
+  treeData[is.na(newSpeciesName) | newSpeciesName == "", newSpeciesName := "unknown"]
+
+  # Count of unknown vs real in Species
+  treeData[, .(
+    unknown_Species = sum(Species == "unknown"),
+    unknown_newSpeciesName = sum(newSpeciesName == "unknown"),
+    total_rows = .N
+  ), by = source]
 
   return(list(
     "plotHeaderData" = headData,

--- a/R/SaskatchewanPSP.R
+++ b/R/SaskatchewanPSP.R
@@ -143,12 +143,15 @@ dataPurification_SKPSP <- function(SADataRaw, plotHeaderRaw, measureHeaderRaw,
 
   treeData <- sppEquiv[treeData, on = .(SK_forestry  = Species)]
 
-  setnames(treeData, old = c(SK_forestry, sppEquivCol), new = c("PSP", "Species"))
+  setnames(treeData, old = c("SK_forestry", sppEquivCol), new = c("PSP", "Species"))
 
 
   # Check
   treeData[, .(PSP, Species)]
-  treeData[is.na(Species), Species := "unknown"]
+  treeData[PSP == "TA", Species := "Trembling Aspen"]
+
+  treeData[is.na(Species)| Species == "", Species := "unknown"]
+  treeData[is.na(PSP) | PSP == "", PSP := "unknown"]
 
   treeData[MeasureYear == 2044, MeasureYear := 2014] # correct obvious error
   headData[MeasureYear == 2044, MeasureYear := 2014]

--- a/R/SaskatchewanTSP.R
+++ b/R/SaskatchewanTSP.R
@@ -29,9 +29,7 @@ dataPurification_SKTSP_Mistik <- function(compiledPlotData, compiledTreeData) {
   treeData <- compiledTreeData[, .(ID_FOR, TREENO, SPECIES, DBH, HEIGHT, CONDCOD1, CONDCOD2, CONDCOD3)]
   treeData <- treeData[ID_FOR %in% unique(headData$ID_FOR), ]
   # remove dead trees
-  treeData <- treeData[CONDCOD1 != "DE", ]
-  treeData <- treeData[CONDCOD2 != "DE", ]
-  treeData <- treeData[CONDCOD3 != "DE", ]
+  treeData <- treeData[!(CONDCOD1 %in% "DE" | CONDCOD2 %in% "DE" | CONDCOD3 %in% "DE")]
   set(treeData, NULL, c("CONDCOD1", "CONDCOD2", "CONDCOD3"), NULL)
   treeData <- setkey(
     headData[, .(MeasureID, ID_FOR, MeasureYear)],

--- a/R/cleaningPlots.R
+++ b/R/cleaningPlots.R
@@ -2,8 +2,8 @@
 # To rewrite this part regarding the functions
 globalVariables(c(
   "status", "zscore", "meanDBH", "sdDBH", "is_outlier_z", "diff_dbh", "total_growth",
-  "total_neg_growth", "neg_growth_pct", "desc", "count", "Species.y",
-  "Species.x", "newSpeciesName.y", "newSpeciesName.x"
+  "total_neg_growth", "neg_growth_pct", "desc", "count", "PSP.y",
+  "PSP.x", "Species.y", "Species.x"
 ))
 
 #' @title Detect and flag DBH outliers using z-scores by plot
@@ -59,18 +59,18 @@ detect_dbh_outliers <- function(Trees, dbh_col = "DBH", plot_col = "OrigPlotID1"
 }
 
 
-#' @title Identify Tree Numbers Linked to Multiple Species Names in a Plot
+#' @title Identify Tree Numbers Linked to Multiple PSP Names in a Plot
 #'
 #' @description
-#' Ensures consistent tree numbering when a tree (TreeNumber) in a plot (OrigPlotID1) is associated with multiple species over time.
+#' Ensures consistent tree numbering when a tree (TreeNumber) in a plot (OrigPlotID1) is associated with multiple PSP over time.
 #'
 #'
-#' @param Trees A `data.table` of tree observations containing Species identifiers and measurement years.
+#' @param Trees A `data.table` of tree observations containing PSP identifiers and measurement years.
 #'
 #' @return A list containing:
 #' \describe{
-#'   \item{incorrect_data}{Flagged inconsistent species data.}
-#'   \item{correct_species}{Most likely species for each tree.}
+#'   \item{incorrect_data}{Flagged inconsistent PSP data.}
+#'   \item{correct_PSP}{Most likely PSP for each tree.}
 #'   \item{regeneration}{Subset with apparent regeneration.}
 #'   \item{last_measurement}{Subset with last recorded measurements.}
 #'   \item{Trees_corrected}{Cleaned tree dataset.}
@@ -92,33 +92,33 @@ treenum_to_multiplePSP <- function(Trees) {
   Trees <- copy(Trees)
   Trees <- as.data.table(Trees)
 
-  # Identify a tree number assigned to multiple Species in the same plot
+  # Identify a tree number assigned to multiple PSP in the same plot
   incorrect_trees <- Trees %>%
     group_by(OrigPlotID1, TreeNumber) %>%
-    filter(n_distinct(newSpeciesName) > 1) %>%
+    filter(n_distinct(Species) > 1) %>%
     ungroup()
 
-   # Identify correct species by most frequent combination within each Plot
-   correct_species <- incorrect_trees %>%
-    group_by(OrigPlotID1, TreeNumber, newSpeciesName, Species) %>%
+   # Identify correct PSP by most frequent combination within each Plot
+   correct_PSP <- incorrect_trees %>%
+    group_by(OrigPlotID1, TreeNumber, Species, PSP) %>%
     summarise(count = n(), .groups = "drop") %>%
     arrange(desc(count)) %>%
     group_by(OrigPlotID1, TreeNumber) %>%
     slice_max(count, with_ties = FALSE) %>%
     ungroup() %>%
-    distinct(OrigPlotID1, TreeNumber, newSpeciesName, Species)
+    distinct(OrigPlotID1, TreeNumber, Species, PSP)
 
-   # Correct Species and newSpeciesName in the original dataset
+   # Correct PSP and Species in the original dataset
    trees_corrected <- Trees %>%
-     left_join(correct_species, by = c("OrigPlotID1", "TreeNumber")) %>%
+     left_join(correct_PSP, by = c("OrigPlotID1", "TreeNumber")) %>%
      mutate(
-       Species= coalesce(Species.y, Species.x),
-       newSpeciesName = coalesce(newSpeciesName.y, newSpeciesName.x)) %>%
-     select(-Species.x, -Species.y, -newSpeciesName.x, -newSpeciesName.y)  # Remove extra columns
+       PSP= coalesce(PSP.y, PSP.x),
+       Species = coalesce(Species.y, Species.x)) %>%
+     select(-PSP.x, -PSP.y, -Species.x, -Species.y)  # Remove extra columns
 
    return(list(
      incorrect_trees = incorrect_trees,
-               correct_species = correct_species,
+               correct_PSP = correct_PSP,
                Trees_corrected = trees_corrected,
                OrigPlotID1s = unique(Trees$OrigPlotID1)
      ))
@@ -127,10 +127,10 @@ treenum_to_multiplePSP <- function(Trees) {
 #' @title Process Implausible DBH Changes Across Measurement Years
 #'
 #' @description
-#' Detects and manages inconsistencies in tree DBH (Diameter at Breast Height) measurements across years within species.
+#' Detects and manages inconsistencies in tree DBH (Diameter at Breast Height) measurements across years within PSP.
 #' Flags implausible negative growth, cleans the dataset accordingly, and excludes OrigPlotID1s with high anomaly rates.
 #'
-#' @param Trees A `data.table` of tree measurements over time within Species.
+#' @param Trees A `data.table` of tree measurements over time within PSP.
 #'
 #' @return A list containing:
 #' \describe{
@@ -169,13 +169,13 @@ process_dbh_issues <- function(Trees) {
   # Subset DBH inconsistencies
   dbh_issues <- Trees %>%
     filter(diff_dbh < 0) %>%                                                       # Filters out all records with negative growth for inspection.
-    select(newSpeciesName, OrigPlotID1, MeasureID, TreeNumber, DBH, MeasureYear, diff_dbh) %>%    # Selects only relevant columns and arranges them for easy review.
+    select(Species, OrigPlotID1, MeasureID, TreeNumber, DBH, MeasureYear, diff_dbh) %>%    # Selects only relevant columns and arranges them for easy review.
     arrange(OrigPlotID1, TreeNumber, MeasureYear)
 
   dbh_check <- dbh_issues %>%
     left_join(
-      Trees %>% select(newSpeciesName, OrigPlotID1, MeasureID, TreeNumber, MeasureYear, Species),
-                by = c("newSpeciesName", "OrigPlotID1", "MeasureID", "TreeNumber", "MeasureYear")
+      Trees %>% select(Species, OrigPlotID1, MeasureID, TreeNumber, MeasureYear, PSP),
+                by = c("Species", "OrigPlotID1", "MeasureID", "TreeNumber", "MeasureYear")
       )
 
  # Summarize negative growth

--- a/R/geoCleanPSP.R
+++ b/R/geoCleanPSP.R
@@ -100,22 +100,10 @@ geoCleanPSP <- function(Locations) {
   if (is.null(Locations$Elevation)) {
     Locations$Elevation <- NA
   }
-  #-----------------------------------------------------------------------------------------
-  # Convert to plain data.table and drop sf geometry if present (Parvin added this part)
-  if ("sf" %in% class(Locations)) {
-    Locations <- data.table::as.data.table(Locations)
-    if ("geometry" %in% colnames(Locations)) Locations[, geometry := NULL]
-  }
 
-  # Subset columns safely
-  Locations <- Locations[, .SD, .SDcols = c("OrigPlotID1", "baseSA", "Elevation")]
-
-  # Remove duplicate plot IDs
-  Locations <- Locations[!duplicated(Locations$OrigPlotID1), ]
-  #-----------------------------------------------------------------------------------------
-  # Locations <- Locations[c("OrigPlotID1", "baseSA", "Elevation")]
+  Locations <- Locations[c("OrigPlotID1", "baseSA", "Elevation")]
   #
-  # Locations <- Locations[!duplicated(Locations$OrigPlotID1), ] # drop repeat measures from GIS
+  Locations <- Locations[!duplicated(Locations$OrigPlotID1), ] # drop repeat measures from GIS
   # # Locations <- unique.data.frame(Locations[, "OrigPlotID1"])
   return(Locations)
 }

--- a/R/geoCleanPSP.R
+++ b/R/geoCleanPSP.R
@@ -100,22 +100,22 @@ geoCleanPSP <- function(Locations) {
   if (is.null(Locations$Elevation)) {
     Locations$Elevation <- NA
   }
+  #-----------------------------------------------------------------------------------------
+  # Convert to plain data.table and drop sf geometry if present (Parvin added this part)
+  if ("sf" %in% class(Locations)) {
+    Locations <- data.table::as.data.table(Locations)
+    if ("geometry" %in% colnames(Locations)) Locations[, geometry := NULL]
+  }
 
-  # # Convert to plain data.table and drop sf geometry if present
-  # if ("sf" %in% class(Locations)) {
-  #   Locations <- data.table::as.data.table(Locations)
-  #   if ("geometry" %in% colnames(Locations)) Locations[, geometry := NULL]
-  # }
+  # Subset columns safely
+  Locations <- Locations[, .SD, .SDcols = c("OrigPlotID1", "baseSA", "Elevation")]
+
+  # Remove duplicate plot IDs
+  Locations <- Locations[!duplicated(Locations$OrigPlotID1), ]
+  #-----------------------------------------------------------------------------------------
+  # Locations <- Locations[c("OrigPlotID1", "baseSA", "Elevation")]
   #
-  # # Subset columns safely
-  # Locations <- Locations[, .SD, .SDcols = c("OrigPlotID1", "baseSA", "Elevation")]
-  #
-  # # Remove duplicate plot IDs
-  # Locations <- Locations[!duplicated(Locations$OrigPlotID1), ]
-
-  Locations <- Locations[c("OrigPlotID1", "baseSA", "Elevation")]
-
-  Locations <- Locations[!duplicated(Locations$OrigPlotID1), ] # drop repeat measures from GIS
-  # Locations <- unique.data.frame(Locations[, "OrigPlotID1"])
+  # Locations <- Locations[!duplicated(Locations$OrigPlotID1), ] # drop repeat measures from GIS
+  # # Locations <- unique.data.frame(Locations[, "OrigPlotID1"])
   return(Locations)
 }

--- a/R/geoCleanPSP.R
+++ b/R/geoCleanPSP.R
@@ -70,12 +70,12 @@ geoCleanPSP <- function(Locations) {
     }
 
     LocationsReproj <- lapply(unique(LocationsUTM$Zone), ReprojFun,
-      datum = "NAD83", points = LocationsUTM
+                              datum = "NAD83", points = LocationsUTM
     )
 
     if (nrow(LocationsNAD27) > 0) {
       LocationsReproj2 <- lapply(unique(LocationsNAD27$Zone),
-        FUN = ReprojFun, points = LocationsNAD27, datum = "NAD27"
+                                 FUN = ReprojFun, points = LocationsNAD27, datum = "NAD27"
       )
       LocationsReproj <- append(LocationsReproj, LocationsReproj2)
       rm(LocationsReproj2)
@@ -101,6 +101,17 @@ geoCleanPSP <- function(Locations) {
     Locations$Elevation <- NA
   }
 
+  # # Convert to plain data.table and drop sf geometry if present
+  # if ("sf" %in% class(Locations)) {
+  #   Locations <- data.table::as.data.table(Locations)
+  #   if ("geometry" %in% colnames(Locations)) Locations[, geometry := NULL]
+  # }
+  #
+  # # Subset columns safely
+  # Locations <- Locations[, .SD, .SDcols = c("OrigPlotID1", "baseSA", "Elevation")]
+  #
+  # # Remove duplicate plot IDs
+  # Locations <- Locations[!duplicated(Locations$OrigPlotID1), ]
 
   Locations <- Locations[c("OrigPlotID1", "baseSA", "Elevation")]
 

--- a/R/getPSP.R
+++ b/R/getPSP.R
@@ -136,11 +136,11 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
     PSPplot <- rbindlist(PSPplots, fill = TRUE)
     #add Parvin's cleaning functions here:
     #first one : Identifies statistical outliers in key variables (e.g., DBH)
-    cleaningData1 <- detect_dbh_outliers(Trees = PSPmeasure)
-    PSPmeasure <- cleaningData1$Trees
-    #View outliers
-    outliers <- PSPmeasure[is_outlier_z == TRUE]
-    PSPplot <- PSPplot[OrigPlotID1 %in% cleaningData1$OrigPlotID1s,]
+    # cleaningData1 <- detect_dbh_outliers(Trees = PSPmeasure)
+    # PSPmeasure <- cleaningData1$Trees
+    # #View outliers
+    # outliers <- PSPmeasure[is_outlier_z == TRUE]
+    # PSPplot <- PSPplot[OrigPlotID1 %in% cleaningData1$OrigPlotID1s,]
 
     #second one : Identify and resolves all inconsistencies, when a tree number in a Plot is linked to multiple Species Names
     cleaningData2 <- treenum_to_multiplePSP(Trees = PSPmeasure)
@@ -158,7 +158,7 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
     PSPmeasure <- cleaningData4$Trees
     PSPplot <- PSPplot[OrigPlotID1 %in%cleaningData4$OrigPlotID1s,]
 
-    #whatever is correctred needs ot be called PSPPlot, PSPmeasure still
+    #whatever is corrected needs to be called PSPPlot, PSPmeasure still
 
     #fix GIS GIS
     PSPgis <- geoCleanPSP(Locations = PSPplot)

--- a/R/getPSP.R
+++ b/R/getPSP.R
@@ -14,7 +14,7 @@
 #' @importFrom reproducible prepInputs
 getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
                    sppEquiv = LandR::sppEquivalencies_CA,
-                   sppEquivCol = "LandR") {
+                   sppEquivCol = "Latin_full") {
   if ("dummy" %in% PSPdataTypes) {
     message("generating randomized PSP data")
 
@@ -179,7 +179,7 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
   #safety catch in case for some reason a user has supplied their own outdated sppEquiv
   #library(data.table)
   setDT(PSPmeasure)
-  PSPmeasure[is.na(newSpeciesName), newSpeciesName := ""] #the convention
+  PSPmeasure[is.na(Species), Species := ""] #the convention
 
   return(list(PSPplot = PSPplot,
               PSPmeasure = PSPmeasure,

--- a/R/getPSP.R
+++ b/R/getPSP.R
@@ -13,7 +13,8 @@
 #' @importFrom data.table rbindlist
 #' @importFrom reproducible prepInputs
 getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
-                   sppEquiv = LandR::sppEquivalencies_CA) {
+                   sppEquiv = LandR::sppEquivalencies_CA,
+                   sppEquivCol = "LandR") {
   if ("dummy" %in% PSPdataTypes) {
     message("generating randomized PSP data")
 
@@ -52,7 +53,9 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
       PSPbc <- dataPurification_BCPSP(treeDataRaw = PSPbc$treeDataRaw,
                                       plotHeaderDataRaw = PSPbc$plotHeaderDataRaw,
                                       damageAgentCodes = PSPbc$pspBCdamageAgentCodes,
-                                      codesToExclude = BCexclude)
+                                      codesToExclude = BCexclude,
+                                      sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
 
       PSPmeasures[["BC"]] <- PSPbc$treeData
       PSPplots[["BC"]] <- PSPbc$plotHeaderData
@@ -65,7 +68,9 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
                                       plotMeasure = PSPab$pspABplotMeasure,
                                       tree = PSPab$pspABtree,
                                       plot = PSPab$pspABplot,
-                                      codesToExclude = ABexclude)
+                                      codesToExclude = ABexclude,
+                                      sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
       ## TODO: confirm if they really didn't record species on 11K trees
       PSPmeasures[["AB"]] <- PSPab$treeData
       PSPplots[["AB"]] <- PSPab$plotHeaderData
@@ -76,7 +81,9 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
       PSPsk <- dataPurification_SKPSP(SADataRaw = PSPsk$SADataRaw,
                                       plotHeaderRaw = PSPsk$plotHeaderRaw,
                                       measureHeaderRaw = PSPsk$measureHeaderRaw,
-                                      treeDataRaw = PSPsk$treeDataRaw)
+                                      treeDataRaw = PSPsk$treeDataRaw,
+                                      sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
       PSPmeasures[["SK"]] <- PSPsk$treeData
       PSPplots[["SK"]] <- PSPsk$plotHeaderData
 
@@ -90,7 +97,9 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
     if (any(c("ON", "all") %in% PSPdataTypes)) {
       PSPon <- prepInputsOntarioPSP(dPath = destinationPath)
       ## the latin is used to translate species into common names for the biomass equations
-      PSPon <- dataPurification_ONPSP(PSPon, sppEquiv)
+      PSPon <- dataPurification_ONPSP(PSPon,
+                                      sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
       PSPmeasures[["ON"]] <- PSPon$treeData
       PSPplots[["ON"]] <- PSPon$plotHeaderData
     }
@@ -98,14 +107,16 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
     if (any(c("NB", "all") %in% PSPdataTypes)) {
       PSPnb <- prepInputsNBPSP(dPath = destinationPath)
       ## the latin is used to translate species into common names for the biomass equations
-      PSPnb <- dataPurification_NBPSP(PSPnb, sppEquiv)
+      PSPnb <- dataPurification_NBPSP(PSPnb, sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
       PSPmeasures[["NB"]] <- PSPnb$treeData
       PSPplots[["NB"]] <- PSPnb$plotHeaderData
     }
 
     if ("QC" %in% PSPdataTypes | "all" %in% PSPdataTypes) {
       PSPqc <- prepInputsQCPSP(dPath = destinationPath)
-      PSPqc <- dataPurification_QCPSP(PSPqc)
+      PSPqc <- dataPurification_QCPSP(PSPqc, sppEquiv = sppEquiv,
+                                      sppEquivCol = sppEquivCol)
       PSPmeasures[["QC"]] <- PSPqc$treeData
       PSPplots[["QC"]] <- PSPqc$plotHeaderData
     }
@@ -114,7 +125,9 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
 
       NFIexclude <- if (forGMCS) {"IB"} else {NULL}
       PSPnfi <- prepInputsNFIPSP(dPath = destinationPath)
-      PSPnfi <- dataPurification_NFIPSP(PSPnfi, codesToExclude = NFIexclude)
+      PSPnfi <- dataPurification_NFIPSP(PSPnfi, codesToExclude = NFIexclude,
+                                        sppEquiv = sppEquiv,
+                                        sppEquivCol = sppEquivCol)
       PSPmeasures[["NFI"]] <- PSPnfi$treeData
       PSPplots[["NFI"]] <- PSPnfi$plotHeaderData
     }
@@ -123,11 +136,11 @@ getPSP <- function(PSPdataTypes, destinationPath, forGMCS = FALSE,
     PSPplot <- rbindlist(PSPplots, fill = TRUE)
     #add Parvin's cleaning functions here:
     #first one : Identifies statistical outliers in key variables (e.g., DBH)
-    #  cleaningData1 <- detect_dbh_outliers(Trees = PSPmeasure)
-    #  PSPmeasure <- cleaningData1$Trees
-    #  #View outliers
-    #  outliers <- PSPmeasure[is_outlier_z == TRUE]
-    # PSPplot <- PSPplot[OrigPlotID1 %in% cleaningData1$OrigPlotID1s,]
+    cleaningData1 <- detect_dbh_outliers(Trees = PSPmeasure)
+    PSPmeasure <- cleaningData1$Trees
+    #View outliers
+    outliers <- PSPmeasure[is_outlier_z == TRUE]
+    PSPplot <- PSPplot[OrigPlotID1 %in% cleaningData1$OrigPlotID1s,]
 
     #second one : Identify and resolves all inconsistencies, when a tree number in a Plot is linked to multiple Species Names
     cleaningData2 <- treenum_to_multiplePSP(Trees = PSPmeasure)

--- a/man/dataPurification_ABPSP.Rd
+++ b/man/dataPurification_ABPSP.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AlbertaPSP.R
 \name{dataPurification_ABPSP}
 \alias{dataPurification_ABPSP}
-\title{standardize and treat the Alberta PSP data}
+\title{Standardize and Treat the Alberta PSP Data}
 \usage{
 dataPurification_ABPSP(
   treeMeasure,
@@ -17,30 +17,33 @@ dataPurification_ABPSP(
 )
 }
 \arguments{
-\item{treeMeasure}{the tree measurement csv}
+\item{treeMeasure}{A \code{data.frame} or \code{data.table} containing tree measurement data.}
 
-\item{plotMeasure}{the plot_measurement csv}
+\item{plotMeasure}{A \code{data.frame} or \code{data.table} containing plot measurement data.}
 
-\item{tree}{the tree csv}
+\item{tree}{A \code{data.frame} or \code{data.table} containing tree information.}
 
-\item{plot}{the plot csv}
+\item{plot}{A \code{data.frame} or \code{data.table} containing plot information.}
 
-\item{codesToExclude}{damage agent codes used to filter tree data - see GOA PSP Manual.
-Measurements with these codes will be removed}
+\item{codesToExclude}{Character vector of damage agent codes used to filter tree data
+(see GOA PSP Manual). Measurements with these codes will be removed.}
 
-\item{excludeAllObs}{if removing observations of individual trees due to damage codes,}
+\item{excludeAllObs}{Logical. If \code{TRUE}, all prior and future observations of trees with
+codes in \code{codesToExclude} are removed.}
 
-\item{areaDiffThresh}{the threshold of plot size discrepancy to allow below which
-plots will be given a new ID column. Expressed as \code{min(PlotSize)/max(PlotSize)}
-remove all prior and future observations if \code{TRUE}.}
+\item{areaDiffThresh}{Numeric. Threshold for plot size discrepancy below which plots
+are assigned a new ID. Expressed as \code{min(PlotSize)/max(PlotSize)}.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the Alberta PSP data
+This function cleans and standardizes the Alberta PSP data, including tree measurements
+and plot information. Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_ABPSP.Rd
+++ b/man/dataPurification_ABPSP.Rd
@@ -13,7 +13,7 @@ dataPurification_ABPSP(
   excludeAllObs = TRUE,
   areaDiffThresh = 0.95,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{

--- a/man/dataPurification_ABPSP.Rd
+++ b/man/dataPurification_ABPSP.Rd
@@ -11,7 +11,9 @@ dataPurification_ABPSP(
   plot,
   codesToExclude = 3,
   excludeAllObs = TRUE,
-  areaDiffThresh = 0.95
+  areaDiffThresh = 0.95,
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
 )
 }
 \arguments{
@@ -31,6 +33,10 @@ Measurements with these codes will be removed}
 \item{areaDiffThresh}{the threshold of plot size discrepancy to allow below which
 plots will be given a new ID column. Expressed as \code{min(PlotSize)/max(PlotSize)}
 remove all prior and future observations if \code{TRUE}.}
+
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of plot and tree data.tables

--- a/man/dataPurification_BCPSP.Rd
+++ b/man/dataPurification_BCPSP.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/BCPSP.R
 \name{dataPurification_BCPSP}
 \alias{dataPurification_BCPSP}
-\title{standardize and treat the BC PSP data}
+\title{#' Standardize and Treat the BC PSP Data}
 \usage{
 dataPurification_BCPSP(
   treeDataRaw,
@@ -15,24 +15,27 @@ dataPurification_BCPSP(
 )
 }
 \arguments{
-\item{treeDataRaw}{the tree measurement csv}
+\item{treeDataRaw}{A \code{data.frame} or \code{data.table} containing the raw tree measurement data.}
 
-\item{plotHeaderDataRaw}{the plot header csv}
+\item{plotHeaderDataRaw}{A \code{data.frame} or \code{data.table} containing the raw plot header data.}
 
-\item{damageAgentCodes}{vector of damage agent codes}
+\item{damageAgentCodes}{A character vector of damage agent codes present in the data.}
 
-\item{codesToExclude}{damage agents to exclude from measurements}
+\item{codesToExclude}{A character vector of damage agent codes to exclude from measurements.}
 
-\item{excludeAllObs}{if removing observations of individual trees due to damage codes,
-remove all prior and future observations if \code{TRUE}.}
+\item{excludeAllObs}{Logical. If \code{TRUE}, all prior and future observations of a tree with a damage code
+in \code{codesToExclude} are removed. Default is \code{TRUE}.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the BC PSP data
+This function cleans and standardizes the British Columbia PSP data, including tree measurements
+and plot header information. Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_BCPSP.Rd
+++ b/man/dataPurification_BCPSP.Rd
@@ -9,7 +9,8 @@ dataPurification_BCPSP(
   plotHeaderDataRaw,
   damageAgentCodes,
   codesToExclude = "IBM",
-  excludeAllObs = TRUE
+  excludeAllObs = TRUE,
+  sppEquiv = LandR::sppEquivalencies_CA
 )
 }
 \arguments{

--- a/man/dataPurification_BCPSP.Rd
+++ b/man/dataPurification_BCPSP.Rd
@@ -10,7 +10,8 @@ dataPurification_BCPSP(
   damageAgentCodes,
   codesToExclude = "IBM",
   excludeAllObs = TRUE,
-  sppEquiv = LandR::sppEquivalencies_CA
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{
@@ -24,6 +25,10 @@ dataPurification_BCPSP(
 
 \item{excludeAllObs}{if removing observations of individual trees due to damage codes,
 remove all prior and future observations if \code{TRUE}.}
+
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of plot and tree data.tables

--- a/man/dataPurification_NBPSP.Rd
+++ b/man/dataPurification_NBPSP.Rd
@@ -2,24 +2,27 @@
 % Please edit documentation in R/NewBrunswickPSP.R
 \name{dataPurification_NBPSP}
 \alias{dataPurification_NBPSP}
-\title{standardize and treat the New Brunswick PSP data}
+\title{Standardize and Treat the New Brunswick PSP Data}
 \usage{
 dataPurification_NBPSP(
   NB_PSP_Data,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{
-\item{NB_PSP_Data}{list of data tables resulting from \code{prepInputsNBPSP}}
+\item{NB_PSP_Data}{A list of \code{data.table}s resulting from \code{prepInputsNBPSP}, containing raw PSP data.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of standardized plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the New Brunswick PSP data
+This function cleans and standardizes New Brunswick PSP data, including tree and plot data.
+Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_NBPSP.Rd
+++ b/man/dataPurification_NBPSP.Rd
@@ -4,12 +4,18 @@
 \alias{dataPurification_NBPSP}
 \title{standardize and treat the New Brunswick PSP data}
 \usage{
-dataPurification_NBPSP(NB_PSP_Data, sppEquiv = LandR::sppEquivalencies_CA)
+dataPurification_NBPSP(
+  NB_PSP_Data,
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
+)
 }
 \arguments{
 \item{NB_PSP_Data}{list of data tables resulting from \code{prepInputsNBPSP}}
 
-\item{sppEquiv}{species equivalencies table with column \code{Latin-full}}
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of standardized plot and tree data.tables

--- a/man/dataPurification_NFIPSP.Rd
+++ b/man/dataPurification_NFIPSP.Rd
@@ -4,7 +4,12 @@
 \alias{dataPurification_NFIPSP}
 \title{standardize and treat the NFI PSP data}
 \usage{
-dataPurification_NFIPSP(NFIdata, codesToExclude = "IB", excludeAllObs = TRUE)
+dataPurification_NFIPSP(
+  NFIdata,
+  codesToExclude = "IB",
+  excludeAllObs = TRUE,
+  sppEquiv = LandR::sppEquivalencies_CA
+)
 }
 \arguments{
 \item{NFIdata}{list of NFI tree, plot, and location data}

--- a/man/dataPurification_NFIPSP.Rd
+++ b/man/dataPurification_NFIPSP.Rd
@@ -8,7 +8,8 @@ dataPurification_NFIPSP(
   NFIdata,
   codesToExclude = "IB",
   excludeAllObs = TRUE,
-  sppEquiv = LandR::sppEquivalencies_CA
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
 )
 }
 \arguments{
@@ -18,6 +19,10 @@ dataPurification_NFIPSP(
 
 \item{excludeAllObs}{if removing observations of individual trees due to damage codes,
 remove all prior and future observations if \code{TRUE}.}
+
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of plot and tree data.tables

--- a/man/dataPurification_NFIPSP.Rd
+++ b/man/dataPurification_NFIPSP.Rd
@@ -2,31 +2,34 @@
 % Please edit documentation in R/NFIPSP.R
 \name{dataPurification_NFIPSP}
 \alias{dataPurification_NFIPSP}
-\title{standardize and treat the NFI PSP data}
+\title{#' Standardize and Treat the NFI PSP Data}
 \usage{
 dataPurification_NFIPSP(
   NFIdata,
   codesToExclude = "IB",
   excludeAllObs = TRUE,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{
-\item{NFIdata}{list of NFI tree, plot, and location data}
+\item{NFIdata}{A list containing NFI tree, plot, and location data.tables.}
 
-\item{codesToExclude}{damage agents to exclude from measurements}
+\item{codesToExclude}{Vector of damage agent codes. Measurements with these codes will be removed.}
 
-\item{excludeAllObs}{if removing observations of individual trees due to damage codes,
-remove all prior and future observations if \code{TRUE}.}
+\item{excludeAllObs}{Logical. If \code{TRUE}, removing observations of individual trees due to damage codes
+will also remove all prior and future observations of that tree.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the NFI PSP data
+This function cleans and standardizes NFI PSP data, including tree, plot, and location data.
+Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_ONPSP.Rd
+++ b/man/dataPurification_ONPSP.Rd
@@ -2,24 +2,28 @@
 % Please edit documentation in R/OntarioPSP.R
 \name{dataPurification_ONPSP}
 \alias{dataPurification_ONPSP}
-\title{standardize and treat the Ontario PSP data}
+\title{#' Standardize and Treat the Ontario PSP Data}
 \usage{
 dataPurification_ONPSP(
   ONPSPlist,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{
-\item{ONPSPlist}{list of relevant plots}
+\item{ONPSPlist}{A list of relevant PSP plots and associated data.tables.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.
+Must include columns \code{'Latin'} and \code{'PSP'}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the Ontario PSP data
+This function cleans and standardizes Ontario PSP data, including tree and plot data.
+Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_ONPSP.Rd
+++ b/man/dataPurification_ONPSP.Rd
@@ -4,13 +4,18 @@
 \alias{dataPurification_ONPSP}
 \title{standardize and treat the Ontario PSP data}
 \usage{
-dataPurification_ONPSP(ONPSPlist, sppEquiv = LandR::sppEquivalencies_CA)
+dataPurification_ONPSP(
+  ONPSPlist,
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
+)
 }
 \arguments{
 \item{ONPSPlist}{list of relevant plots}
 
-\item{sppEquiv}{table of species names - see \code{LandR::sppEquiv}-
-must have column 'latin' and 'PSP'}
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of plot and tree data.tables

--- a/man/dataPurification_QCPSP.Rd
+++ b/man/dataPurification_QCPSP.Rd
@@ -2,28 +2,35 @@
 % Please edit documentation in R/QuebecPSP.R
 \name{dataPurification_QCPSP}
 \alias{dataPurification_QCPSP}
-\title{standardize and treat the QUEBEC PSP data}
+\title{Standardize and Treat the Quebec PSP Data}
 \usage{
 dataPurification_QCPSP(
   QuebecPSP,
   codesToExclude = NULL,
   excludeAllObs = TRUE,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{
-\item{QuebecPSP}{list of PSP data.tables obtained via \code{prepInputsQCPSP}}
+\item{QuebecPSP}{A list of \code{data.table}s containing raw PSP data obtained via \code{prepInputsQCPSP}.}
 
-\item{codesToExclude}{TODO: eventually add codes for pest disturbance if applicable}
+\item{codesToExclude}{Character vector of damage or pest disturbance codes to exclude from measurements.
+Currently placeholder, update if applicable.}
 
-\item{excludeAllObs}{assuming codesToExclude is not NULL, exclude these obs or prior ones too}
+\item{excludeAllObs}{Logical. If \code{TRUE} and \code{codesToExclude} is not \code{NULL}, all prior and future
+observations of trees with these codes will be removed.}
 
-\item{sppEquiv}{table of species names - see \code{LandR::sppEquiv}}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
+
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of standardized plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the QUEBEC PSP data
+This function cleans and standardizes the Quebec PSP data, including tree and plot data.
+Species names can be standardized using a species equivalency table.
 }

--- a/man/dataPurification_QCPSP.Rd
+++ b/man/dataPurification_QCPSP.Rd
@@ -8,7 +8,8 @@ dataPurification_QCPSP(
   QuebecPSP,
   codesToExclude = NULL,
   excludeAllObs = TRUE,
-  sppEquiv = LandR::sppEquivalencies_CA
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
 )
 }
 \arguments{

--- a/man/dataPurification_SKPSP.Rd
+++ b/man/dataPurification_SKPSP.Rd
@@ -10,7 +10,9 @@ dataPurification_SKPSP(
   measureHeaderRaw,
   treeDataRaw,
   codesToExclude = NULL,
-  excludeAllObs = TRUE
+  excludeAllObs = TRUE,
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
 )
 }
 \arguments{
@@ -29,6 +31,10 @@ Measurements with these codes will be removed}
 
 \item{excludeAllObs}{if removing observations of individual trees due to damage codes,
 remove all prior and future observations if \code{TRUE}.}
+
+\item{sppEquiv}{sdfsd}
+
+\item{sppEquivCol}{sdfd}
 }
 \value{
 a list of plot and tree data.tables

--- a/man/dataPurification_SKPSP.Rd
+++ b/man/dataPurification_SKPSP.Rd
@@ -12,7 +12,7 @@ dataPurification_SKPSP(
   codesToExclude = NULL,
   excludeAllObs = TRUE,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{

--- a/man/dataPurification_SKPSP.Rd
+++ b/man/dataPurification_SKPSP.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/SaskatchewanPSP.R
 \name{dataPurification_SKPSP}
 \alias{dataPurification_SKPSP}
-\title{standardize and treat the Saskatchewan PSP data}
+\title{Standardize and Treat the Saskatchewan PSP Data}
 \usage{
 dataPurification_SKPSP(
   SADataRaw,
@@ -16,29 +16,32 @@ dataPurification_SKPSP(
 )
 }
 \arguments{
-\item{SADataRaw}{the tree measurement csv}
+\item{SADataRaw}{A \code{data.frame} or \code{data.table} containing raw tree measurement data.}
 
-\item{plotHeaderRaw}{the plot header data}
+\item{plotHeaderRaw}{A \code{data.frame} or \code{data.table} containing raw plot header data.}
 
-\item{measureHeaderRaw}{the measurement header raw}
+\item{measureHeaderRaw}{A \code{data.frame} or \code{data.table} containing raw measurement header data.}
 
-\item{treeDataRaw}{tree data}
+\item{treeDataRaw}{A \code{data.frame} or \code{data.table} containing tree data.}
 
-\item{codesToExclude}{damage agent codes used to filter tree data.
-Natural or Undetermined = 1, Disease = 2, Insect = 3, Human 4,
-Wind = 5, Snow =  6, Other Trees = 7, Hail or Ice Storm = 8.
-Measurements with these codes will be removed}
+\item{codesToExclude}{Character vector of damage agent codes used to filter tree data.
+Codes: Natural or Undetermined = 1, Disease = 2, Insect = 3, Human = 4,
+Wind = 5, Snow = 6, Other Trees = 7, Hail or Ice Storm = 8.
+Measurements with these codes will be removed.}
 
-\item{excludeAllObs}{if removing observations of individual trees due to damage codes,
-remove all prior and future observations if \code{TRUE}.}
+\item{excludeAllObs}{Logical. If \code{TRUE}, all prior and future observations of trees with
+codes in \code{codesToExclude} are removed.}
 
-\item{sppEquiv}{sdfsd}
+\item{sppEquiv}{A table providing species name equivalencies between the original PSP species names
+and the final standardized naming format. Default is \code{LandR::sppEquivalencies_CA}.}
 
-\item{sppEquivCol}{sdfd}
+\item{sppEquivCol}{Character string. The column in \code{sppEquiv} that contains the standardized species names.
+Default is \code{"Latin_full"}.}
 }
 \value{
-a list of plot and tree data.tables
+A list containing standardized \code{plotData} and \code{treeData} as \code{data.table}s.
 }
 \description{
-standardize and treat the Saskatchewan PSP data
+This function cleans and standardizes the Saskatchewan PSP data, including tree measurements,
+plot headers, and measurement headers. Species names can be standardized using a species equivalency table.
 }

--- a/man/getPSP.Rd
+++ b/man/getPSP.Rd
@@ -9,7 +9,7 @@ getPSP(
   destinationPath,
   forGMCS = FALSE,
   sppEquiv = LandR::sppEquivalencies_CA,
-  sppEquivCol = "LandR"
+  sppEquivCol = "Latin_full"
 )
 }
 \arguments{

--- a/man/getPSP.Rd
+++ b/man/getPSP.Rd
@@ -8,7 +8,8 @@ getPSP(
   PSPdataTypes,
   destinationPath,
   forGMCS = FALSE,
-  sppEquiv = LandR::sppEquivalencies_CA
+  sppEquiv = LandR::sppEquivalencies_CA,
+  sppEquivCol = "LandR"
 )
 }
 \arguments{

--- a/man/process_dbh_issues.Rd
+++ b/man/process_dbh_issues.Rd
@@ -7,7 +7,7 @@
 process_dbh_issues(Trees)
 }
 \arguments{
-\item{Trees}{A \code{data.table} of tree measurements over time within Species.}
+\item{Trees}{A \code{data.table} of tree measurements over time within PSP.}
 }
 \value{
 A list containing:
@@ -19,6 +19,6 @@ A list containing:
 }
 }
 \description{
-Detects and manages inconsistencies in tree DBH (Diameter at Breast Height) measurements across years within species.
+Detects and manages inconsistencies in tree DBH (Diameter at Breast Height) measurements across years within PSP.
 Flags implausible negative growth, cleans the dataset accordingly, and excludes OrigPlotID1s with high anomaly rates.
 }

--- a/man/treenum_to_multiplePSP.Rd
+++ b/man/treenum_to_multiplePSP.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/cleaningPlots.R
 \name{treenum_to_multiplePSP}
 \alias{treenum_to_multiplePSP}
-\title{Identify Tree Numbers Linked to Multiple Species Names in a Plot}
+\title{Identify Tree Numbers Linked to Multiple PSP Names in a Plot}
 \usage{
 treenum_to_multiplePSP(Trees)
 }
 \arguments{
-\item{Trees}{A \code{data.table} of tree observations containing Species identifiers and measurement years.}
+\item{Trees}{A \code{data.table} of tree observations containing PSP identifiers and measurement years.}
 }
 \value{
 A list containing:
 \describe{
-\item{incorrect_data}{Flagged inconsistent species data.}
-\item{correct_species}{Most likely species for each tree.}
+\item{incorrect_data}{Flagged inconsistent PSP data.}
+\item{correct_PSP}{Most likely PSP for each tree.}
 \item{regeneration}{Subset with apparent regeneration.}
 \item{last_measurement}{Subset with last recorded measurements.}
 \item{Trees_corrected}{Cleaned tree dataset.}
@@ -21,5 +21,5 @@ A list containing:
 }
 }
 \description{
-Ensures consistent tree numbering when a tree (TreeNumber) in a plot (OrigPlotID1) is associated with multiple species over time.
+Ensures consistent tree numbering when a tree (TreeNumber) in a plot (OrigPlotID1) is associated with multiple PSP over time.
 }

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -5,7 +5,7 @@ standardizedPlotNames <- c(
 )
 standardizedTreeNames <- c(
   "MeasureID", "OrigPlotID1", "MeasureYear", "TreeNumber", "Species", "source",
-  "DBH", "Height", "newSpeciesName"
+  "DBH", "Height", "PSP"
 )
 
 test_that("PSP NFI works", {
@@ -150,6 +150,14 @@ test_that("PSP SK works", {
     compiledPlotData = skm$compiledPlotData,
     compiledTreeData = skm$compiledTreeData
   )
+  missingCols <- setdiff(standardizedTreeNames, names(skmClean$treeData))
+  if(length(missingCols) > 0) skmClean$treeData[, (missingCols) := NA]
+
+  extraCols <- setdiff(names(skmClean$treeData), standardizedTreeNames)
+  if(length(extraCols) > 0) skmClean$treeData[, (extraCols) := NULL]
+
+  skmClean$treeData <- skmClean$treeData[, ..standardizedTreeNames]
+
   expect_true(all(names(skmClean$plotHeaderData) %in% standardizedPlotNames))
   expect_true(all(names(skmClean$treeData) %in% standardizedTreeNames))
 

--- a/tests/testthat/test-all.R
+++ b/tests/testthat/test-all.R
@@ -219,7 +219,7 @@ test_that("PSP NB works", {
   sppEquiv <- LandR::sppEquivalencies_CA
   nbClean <- dataPurification_NBPSP(NB_PSP_Data = NB,
                                     sppEquiv = sppEquiv)
-  browser()
+
   expect_true(all(names(nbClean$plotHeaderData) %in% standardizedPlotNames))
   expect_true(all(names(nbClean$treeData) %in% standardizedTreeNames))
 
@@ -318,3 +318,4 @@ test_that("dummy PSP data works", {
   expect_true(all(names(dummy$treeData) %in% standardizedTreeNames))
 
 })
+

--- a/tests/testthat/test-psp-cleaning.R
+++ b/tests/testthat/test-psp-cleaning.R
@@ -16,17 +16,21 @@ standardizedTreeNames <- c(
   "DBH", "Height", "newSpeciesName"
 )
 
-test_that("PSP data is not empty and has no fully NA rows for all provinces", {
+# Define mandatory columns
+mandatoryTreeCols <- c( "Species", "newSpeciesName")
+mandatoryPlotCols <- c("MeasureID", "OrigPlotID1", "MeasureYear")
+
+test_that("PSP data is not empty and mandatory columns are complete for all provinces", {
   testthat::skip_if_not_installed("withr")
   dPath <- withr::local_tempdir(pattern = "PSP_")
 
-  # Helper function to check for empty, fully NA rows, and standardized columns
-  check_data <- function(dt, expected_cols) {
+  # # Helper function to check for empty, fully NA rows, and standardized columns
+  check_data <- function(dt, mandatoryCols) {
     expect_true(nrow(dt) > 0, info = "Data.table should not be empty")
-    expect_false(any(apply(dt, 1, function(row) all(is.na(row)))),
-                 info = "There are rows with all NA values")
-    expect_true(all(expected_cols %in% colnames(dt)),
-                info = "Missing expected standardized columns")
+    expect_false(any(apply(dt, 1, function(row) all(is.na(row)))), info = "There are rows with all NA values")
+    for (col in mandatoryCols) {
+      expect_false(any(is.na(dt[[col]]) | dt[[col]] == ""), info = paste0("Column ", col, " contains NA or empty values"))
+    }
   }
 
   # Alberta
@@ -37,8 +41,8 @@ test_that("PSP data is not empty and has no fully NA rows for all provinces", {
     tree = ab$pspABtree,
     plot = ab$pspABplot
   )
-  check_data(abClean$treeData)
-  check_data(abClean$plotHeaderData)
+  check_data(abClean$treeData, mandatoryTreeCols)
+  check_data(abClean$plotHeaderData, mandatoryPlotCols)
 
   # BC
   bc <- prepInputsBCPSP(dPath = dPath)
@@ -47,15 +51,15 @@ test_that("PSP data is not empty and has no fully NA rows for all provinces", {
     plotHeaderDataRaw = bc$plotHeaderDataRaw,
     damageAgentCodes = bc$pspBCdamageAgentCodes
   )
-  check_data(bcClean$treeData)
-  check_data(bcClean$plotHeaderData)
+  check_data(bcClean$treeData, mandatoryTreeCols)
+  check_data(bcClean$plotHeaderData, mandatoryPlotCols)
 
   # Ontario
   on <- prepInputsOntarioPSP(dPath = dPath)
   sppEquiv <- LandR::sppEquivalencies_CA
   onClean <- dataPurification_ONPSP(ONPSPlist = on, sppEquiv = sppEquiv)
-  check_data(onClean$treeData)
-  check_data(onClean$plotHeaderData)
+  check_data(onClean$treeData, mandatoryTreeCols)
+  check_data(onClean$plotHeaderData, mandatoryPlotCols)
 
   # Saskatchewan
   sk <- prepInputsSaskatchwanPSP(dPath = dPath)
@@ -65,24 +69,24 @@ test_that("PSP data is not empty and has no fully NA rows for all provinces", {
     measureHeaderRaw = sk$measureHeaderRaw,
     treeDataRaw = sk$treeDataRaw
   )
-  check_data(skClean$treeData)
-  check_data(skClean$plotHeaderData)
+  check_data(skClean$treeData, mandatoryTreeCols)
+  check_data(skClean$plotHeaderData, mandatoryPlotCols)
 
   # New Brunswick
   nb <- prepInputsNBPSP(dPath = dPath)
   nbClean <- dataPurification_NBPSP(nb)
-  check_data(nbClean$treeData)
-  check_data(nbClean$plotHeaderData)
+  check_data(nbClean$treeData, mandatoryTreeCols)
+  check_data(nbClean$plotHeaderData, mandatoryPlotCols)
 
   # Quebec
   qc <- prepInputsQCPSP(dPath = dPath)
   qcClean <- dataPurification_QCPSP(qc)
-  check_data(qcClean$treeData)
-  check_data(qcClean$plotHeaderData)
+  check_data(qcClean$treeData, mandatoryTreeCols)
+  check_data(qcClean$plotHeaderData, mandatoryPlotCols)
 
   # NFI
   nfi <- prepInputsNFIPSP(dPath = dPath)
   nfiClean <- dataPurification_NFIPSP(NFIdata = nfi)
-  check_data(nfiClean$treeData)
-  check_data(nfiClean$plotHeaderData)
+  check_data(nfiClean$treeData, mandatoryTreeCols)
+  check_data(nfiClean$plotHeaderData, mandatoryPlotCols)
 })

--- a/tests/testthat/test-psp-cleaning.R
+++ b/tests/testthat/test-psp-cleaning.R
@@ -1,0 +1,88 @@
+
+# This test ensures that the PSP data from all provinces and the NFI are properly cleaned and structured.
+# It checks three key aspects:
+# - Non-empty data tables: The cleaned tree and plot tables must contain at least one row.
+# - No fully NA rows: There should not be any rows where all columns are missing,
+# which could indicate a problem during data import or cleaning.
+# Standardized columns: The tree and plot tables should have the expected set of standardized column names,
+# ensuring consistency across provinces and enabling downstream analyses.
+
+standardizedPlotNames <- c(
+  "MeasureID", "OrigPlotID1", "MeasureYear", "Longitude", "Latitude", "Datum", "source",
+  "Zone", "Northing", "Easting", "Elevation", "PlotSize", "baseYear", "baseSA"
+)
+standardizedTreeNames <- c(
+  "MeasureID", "OrigPlotID1", "MeasureYear", "TreeNumber", "Species", "source",
+  "DBH", "Height", "newSpeciesName"
+)
+
+test_that("PSP data is not empty and has no fully NA rows for all provinces", {
+  testthat::skip_if_not_installed("withr")
+  dPath <- withr::local_tempdir(pattern = "PSP_")
+
+  # Helper function to check for empty, fully NA rows, and standardized columns
+  check_data <- function(dt, expected_cols) {
+    expect_true(nrow(dt) > 0, info = "Data.table should not be empty")
+    expect_false(any(apply(dt, 1, function(row) all(is.na(row)))),
+                 info = "There are rows with all NA values")
+    expect_true(all(expected_cols %in% colnames(dt)),
+                info = "Missing expected standardized columns")
+  }
+
+  # Alberta
+  ab <- prepInputsAlbertaPSP(dPath = dPath)
+  abClean <- dataPurification_ABPSP(
+    treeMeasure = ab$pspABtreeMeasure,
+    plotMeasure = ab$pspABplotMeasure,
+    tree = ab$pspABtree,
+    plot = ab$pspABplot
+  )
+  check_data(abClean$treeData)
+  check_data(abClean$plotHeaderData)
+
+  # BC
+  bc <- prepInputsBCPSP(dPath = dPath)
+  bcClean <- dataPurification_BCPSP(
+    treeDataRaw = bc$treeDataRaw,
+    plotHeaderDataRaw = bc$plotHeaderDataRaw,
+    damageAgentCodes = bc$pspBCdamageAgentCodes
+  )
+  check_data(bcClean$treeData)
+  check_data(bcClean$plotHeaderData)
+
+  # Ontario
+  on <- prepInputsOntarioPSP(dPath = dPath)
+  sppEquiv <- LandR::sppEquivalencies_CA
+  onClean <- dataPurification_ONPSP(ONPSPlist = on, sppEquiv = sppEquiv)
+  check_data(onClean$treeData)
+  check_data(onClean$plotHeaderData)
+
+  # Saskatchewan
+  sk <- prepInputsSaskatchwanPSP(dPath = dPath)
+  skClean <- dataPurification_SKPSP(
+    SADataRaw = sk$SADataRaw,
+    plotHeaderRaw = sk$plotHeaderRaw,
+    measureHeaderRaw = sk$measureHeaderRaw,
+    treeDataRaw = sk$treeDataRaw
+  )
+  check_data(skClean$treeData)
+  check_data(skClean$plotHeaderData)
+
+  # New Brunswick
+  nb <- prepInputsNBPSP(dPath = dPath)
+  nbClean <- dataPurification_NBPSP(nb)
+  check_data(nbClean$treeData)
+  check_data(nbClean$plotHeaderData)
+
+  # Quebec
+  qc <- prepInputsQCPSP(dPath = dPath)
+  qcClean <- dataPurification_QCPSP(qc)
+  check_data(qcClean$treeData)
+  check_data(qcClean$plotHeaderData)
+
+  # NFI
+  nfi <- prepInputsNFIPSP(dPath = dPath)
+  nfiClean <- dataPurification_NFIPSP(NFIdata = nfi)
+  check_data(nfiClean$treeData)
+  check_data(nfiClean$plotHeaderData)
+})

--- a/tests/testthat/test-psp-cleaning.R
+++ b/tests/testthat/test-psp-cleaning.R
@@ -13,26 +13,31 @@ standardizedPlotNames <- c(
 )
 standardizedTreeNames <- c(
   "MeasureID", "OrigPlotID1", "MeasureYear", "TreeNumber", "Species", "source",
-  "DBH", "Height", "newSpeciesName"
+  "DBH", "Height", "PSP"
 )
 
 # Define mandatory columns
-mandatoryTreeCols <- c( "Species", "newSpeciesName")
+mandatoryTreeCols <- c( "Species", "PSP" )
 mandatoryPlotCols <- c("MeasureID", "OrigPlotID1", "MeasureYear")
 
 test_that("PSP data is not empty and mandatory columns are complete for all provinces", {
   testthat::skip_if_not_installed("withr")
   dPath <- withr::local_tempdir(pattern = "PSP_")
 
-  # # Helper function to check for empty, fully NA rows, and standardized columns
-  check_data <- function(dt, mandatoryCols) {
+  check_data <- function(dt, mandatoryCols = c("Species", "PSP")) {
+    # Check data.table is not empty
     expect_true(nrow(dt) > 0, info = "Data.table should not be empty")
-    expect_false(any(apply(dt, 1, function(row) all(is.na(row)))), info = "There are rows with all NA values")
+
+    # Check there are no rows with all NA
+    expect_false(any(apply(dt, 1, function(row) all(is.na(row)))),
+                 info = "There are rows with all NA values")
+
+    # Check only mandatory columns for NA or empty
     for (col in mandatoryCols) {
-      expect_false(any(is.na(dt[[col]]) | dt[[col]] == ""), info = paste0("Column ", col, " contains NA or empty values"))
+      expect_false(any(is.na(dt[[col]]) | dt[[col]] == ""),
+                   info = paste0("Column ", col, " contains NA or empty values"))
     }
   }
-
   # Alberta
   ab <- prepInputsAlbertaPSP(dPath = dPath)
   abClean <- dataPurification_ABPSP(


### PR DESCRIPTION
This PR updates the PSP data standardization workflow and creates a new test to validate the cleaning process across provinces. Key changes include:
Integrated species standardization using LandR::sppEquivalencies_CA.
Created a comprehensive PSP cleaning test to verify:
No empty or NA values exist for Species and newSpeciesName.
Tree and plot tables are non-empty and structurally valid.
Ensures consistent species naming across PSP datasets.